### PR TITLE
[gitops-wg] Leo stepdown

### DIFF
--- a/gitops-wg/CHAIRS.md
+++ b/gitops-wg/CHAIRS.md
@@ -4,3 +4,7 @@ Name | Organization | GitHub
 -- | -- | --
 Dan Garfield | Codefresh | [@todaywasawesome](https://github.com/todaywasawesome)
 Scott Rigby | Weaveworks | [@scottrigby](https://github.com/scottrigby)
+
+## Past Chairs
+
+- Leonardo Murillo, [@murillodigital](https://github.com/murillodigital)

--- a/gitops-wg/CHAIRS.md
+++ b/gitops-wg/CHAIRS.md
@@ -3,5 +3,4 @@
 Name | Organization | GitHub
 -- | -- | --
 Dan Garfield | Codefresh | [@todaywasawesome](https://github.com/todaywasawesome)
-Leonardo Murillo | Cloud Native Architects | [@murillodigital](https://github.com/murillodigital)
 Scott Rigby | Weaveworks | [@scottrigby](https://github.com/scottrigby)


### PR DESCRIPTION
Supersedes https://github.com/gitops-working-group/gitops-working-group/pull/185

Today this email was sent to the Tag App Delivery Mailing List <https://lists.cncf.io/g/cncf-tag-app-delivery>.

----

Hi everyone,

Leo is stepping down as a GitOps WG co-chair. He will be staying on as an OpenGitOps maintainer. See Leo’s [note to the community here](https://github.com/gitops-working-group/gitops-working-group/pull/185), and PR to the WG files in the [TAG App Delivery repo here](https://github.com/cncf/tag-app-delivery/pull/176).

Thank you Leo! 💖 we will still see you but with fewer responsibilities for the time being.

Per WG governance, we will hold a special election for a new co-chair. Note [only existing maintainers](https://github.com/open-gitops/project/blob/main/MAINTAINERS) are eligible for nomination. Elections are held on the TAG App Delivery mailing list. Please read the [WG Governance](https://github.com/open-gitops/project/blob/main/GOVERNANCE.md) in full for detailed information on responsibilities for each role in the OpenGitOps and GitOps WG community, the election process itself, and decision-making. This email is part of that process.

Relevant dates:

- Co-chair nominations will be open until this Friday **Jan 21** (giving a full work week), at which point voting opens on the TAG App Delivery mailing list
- Voting open until the following **Friday, Jan 28, 2022**.
- Results will be announced on the TAG mailing list and Slack that Friday

Thank you for your participation!

Scott for the GitOps Working Group Chairs and OpenGitOps Maintainers