### PR TITLE
Add TAG Chairs and Tech Leads as default CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,12 @@
 # the owned files.
 #
 
+# Default owners for everything in the repo
+#
+# Unless a later match takes precedence, these owners will be requested for
+# review when someone opens a pull request.
+*   @AloisReitbauer @Jenniferstrej @hongchaodeng @AlexsJones @thschue
+
 # README.md Owners
 /README.md @AloisReitbauer @Jenniferstrej
 


### PR DESCRIPTION
Write access to directories specified farther below in the file will also now be more targeted

See:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file