### PR TITLE
add multitenancy survey issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/multitenancy.yaml
+++ b/.github/ISSUE_TEMPLATE/multitenancy.yaml
@@ -1,0 +1,53 @@
+---
+# see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Multitenancy use case
+description: Select to provide info on your multitenancy needs and use cases
+title: "[multitenancy] <use case title>"
+labels: 
+  - multitenancy
+  - survey
+assignees:
+  - alexsjones
+  - roberthstrand
+  - joshgav
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Welcome to TAG App Delivery's **multitenancy use case** survey.
+        Thank you for contributing.
+        We will continue discussion with you within the issue.
+  - type: input
+    id: tenant_relationship
+    attributes:
+      label: Tenant relationship
+      description: |
+        How are tenants related to the service provider?
+        E.g., groups within same org, customers, teams in
+        same group.
+    validations:
+      required: true
+  - type: textarea
+    id: multitenancy_implementation
+    attributes:
+      label: Multitenancy implementation
+      description: |
+        How is multitenancy achieved? E.g., separate clusters, separate
+        namespaces in one cluster, virtual cluster in cluster
+    validations:
+      required: true
+  - type: input
+    id: organization
+    attributes:
+      label: Organization
+      description: Name of your organization (optional)
+  - type: textarea
+    id: pains
+    attributes:
+      label: Pains
+      description: What problems have you had with available implementations? (optional)
+  - type: textarea
+    id: suggestions
+    attributes:
+      label: Suggestions
+      description: What suggestions would you make for future implementations? (optional)

--- a/.github/ISSUE_TEMPLATE/multitenancy.yaml
+++ b/.github/ISSUE_TEMPLATE/multitenancy.yaml
@@ -1,7 +1,7 @@
 ---
 # see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
 name: Multitenancy use case
-description: Select to provide info on your multitenancy needs and use cases
+description: Provide info on your multitenancy needs and use cases
 title: "[multitenancy] <use case title>"
 labels: 
   - multitenancy
@@ -15,16 +15,19 @@ body:
     attributes:
       value: |
         Welcome to TAG App Delivery's **multitenancy use case** survey.
-        Thank you for contributing.
-        We will continue discussion with you within the issue.
+
+        TAG App Delivery wants to understand platform providers' use cases for serving multiple tenants.
+        Please share info on the scenario you seek to address through multitenancy, the implementation you now provide, pains you experience and suggestions for the future.
+
+        Thank you for your contributions!
+
+        ---
   - type: input
     id: tenant_relationship
     attributes:
       label: Tenant relationship
       description: |
-        How are tenants related to the service provider?
-        E.g., groups within same org, customers, teams in
-        same group.
+        How are tenants related to the service provider?  E.g., groups within same org, customers, teams in same group.
     validations:
       required: true
   - type: textarea
@@ -32,15 +35,9 @@ body:
     attributes:
       label: Multitenancy implementation
       description: |
-        How is multitenancy achieved? E.g., separate clusters, separate
-        namespaces in one cluster, virtual cluster in cluster
+        How is multitenancy achieved? E.g., separate clusters, separate namespaces in one cluster, virtual cluster in cluster
     validations:
       required: true
-  - type: input
-    id: organization
-    attributes:
-      label: Organization
-      description: Name of your organization (optional)
   - type: textarea
     id: pains
     attributes:
@@ -51,3 +48,8 @@ body:
     attributes:
       label: Suggestions
       description: What suggestions would you make for future implementations? (optional)
+  - type: input
+    id: organization
+    attributes:
+      label: Organization
+      description: Name of your organization (optional)


### PR DESCRIPTION
Per [discussion](https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg/edit#heading=h.arf7zbmvhr5b) in WG Cooperative Delivery today, we'd like to try GitHub issue templates for gathering insights and use cases from developers and users. This first one is to gather info for #193.

I was really excited to find that GitHub's templates now support structured forms, see [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema). I used that here.

If you'd like to see how the issue form will look when merged to main, you can preview it in my fork at <https://github.com/joshgav/tag-app-delivery/issues/new/choose>. See the results of a completed form at <https://github.com/joshgav/tag-app-delivery/issues/1>

If this works out well we can run other info-gathering surveys this way too!

PTAL @roberthstrand @alexsjones