### PR TITLE
add infra survey issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/infrastructure.yaml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yaml
@@ -1,0 +1,52 @@
+---
+# see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Infrastructure for apps use case
+description: Provide info on the infrastructure use cases required by your cloud-native application
+title: "[infrastructure] <use case title>"
+labels: 
+  - infrastructure
+  - survey
+assignees:
+  - roberthstrand
+  - joshgav
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Welcome to TAG App Delivery's **infrastructure for apps** use case survey.
+        
+        TAG App Delivery wants to understand developers' use cases for supporting infrastructure services in cloud-native applications.
+        Please share details about the services your cloud-native apps require, how they are delivered and updated, pains you encounter and suggestions for improvement.
+
+        Thank you for your contributions!
+
+        ---
+  - type: textarea
+    id: service_requirements
+    attributes:
+      label: Service requirements
+      description: |
+        What infrastructure services are required by your team? Consider "infrastructure" to mean any supporting capability maintained by other people on behalf of your application. Examples include datastores, identities, monitoring, stream brokers, and pipelines.
+    validations:
+      required: true
+  - type: textarea
+    id: service_implementation
+    attributes:
+      label: Service implementation
+      description: |
+        How are these infrastructure services delivered, managed, and updated today? Are they provided by an internal team or by a managed provider?  Are they provisioned and maintained via Kubernetes CRDs, Terraform, perhaps manually?
+  - type: textarea
+    id: pains
+    attributes:
+      label: Pains
+      description: What problems have you had with infrastructure delivery for your applications? (optional)
+  - type: textarea
+    id: suggestions
+    attributes:
+      label: Suggestions
+      description: What suggestions would you make for improving infrastructure delivery for applications? (optional)
+  - type: input
+    id: organization
+    attributes:
+      label: Organization
+      description: Name of your organization (optional)


### PR DESCRIPTION
After working on #197 I think it would be a shame not to also offer a form for gathering info about application team's requirements from and problems with cloud-native infrastructure providers. That's info which would help inform strategy and work in WG Cooperative Delivery and we've been discussing how to gather real user input the past few meetings.

The introductory paragraph and questions are influenced by [discussion in yesterday's WG meeting](https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg/edit#heading=h.teean4kur6z9) as well as brainstorming in [this Google doc](https://docs.google.com/document/d/1ANRdTe0wTWdn7zvPwisBV36bvv4a2S6n_MQGpL7uV68).

My thinking is that once this and #197 are integrated we can broadly share a link to the Issue input page at <https://github.com/cncf/tag-app-delivery/issues/new/choose>. This would be our minimally-viable survey :)

WDYT @roberthstrand @chris-short?