### PR TITLE
Add Sebastian to GitOps interested parties

### DIFF
--- a/gitops-wg/interested-parties.md
+++ b/gitops-wg/interested-parties.md
@@ -107,7 +107,7 @@ Weaveworks | Daniel Lizio-Katzen
 Weaveworks | Brice Fernandes
 Weaveworks | Scott Rigby
 Weaveworks | Lucas Käldström
-Weaveworks | Sebastian Bernheim
+Weaveworks | Sebastian Bernheim | sbernheim
 Workday | Adrian Smith
 &nbsp; | Lloyd Chang
 &nbsp; | Tim Sina

--- a/gitops-wg/interested-parties.md
+++ b/gitops-wg/interested-parties.md
@@ -107,6 +107,7 @@ Weaveworks | Daniel Lizio-Katzen
 Weaveworks | Brice Fernandes
 Weaveworks | Scott Rigby
 Weaveworks | Lucas Käldström
+Weaveworks | Sebastian Bernheim
 Workday | Adrian Smith
 &nbsp; | Lloyd Chang
 &nbsp; | Tim Sina


### PR DESCRIPTION
Add Sebastian Bernheim to the GitOps Working Group's interested-parties.md file.