### PR TITLE
remove date from post URL

### DIFF
--- a/cncf.github.io_tag-app-delivery/_config.yml
+++ b/cncf.github.io_tag-app-delivery/_config.yml
@@ -23,6 +23,8 @@ baseurl: "/tag-app-delivery" # the subpath of your site, e.g. /blog
 url: "https://cncf.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: CNCFTagApp
 
+permalink: /:collection/:slug
+
 # Build settings
 theme: minima
 plugins:


### PR DESCRIPTION
This change would remove the date and category from post URLs and replace them with just `posts`, as follows. The date doesn't seem significant enough in our case to include in the URL. It might even distract people and make posts look outdated.

- Previous: `http://127.0.0.1:4000/tag-app-delivery/general/2022/09/12/kubeconna-project-meeting.html`
- With this PR: `http://127.0.0.1:4000/tag-app-delivery/posts/kubeconna-project-meeting`

We should make this change now rather than later cause our older links will break.

WDYT?