### PR TITLE
feat: update maintainers gitops

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,4 +17,4 @@
 /platforms-wg/ @AlexsJones @thschue @roberthstrand @joshgav
 
 # GitOps WG
-/gitops-wg/ @chrispat @csand-msft @todaywasawesome @chris-short @murillodigital @scottrigby @christianh814
+/gitops-wg/ @todaywasawesome @chris-short @murillodigital @scottrigby @christianh814 @JaimeMagiera @niklasmtj @williamcaban @roberthstrand


### PR DESCRIPTION
Updating the CODEOWNERS file to reflect the current maintainers in the OpenGitOps project.

Signed-off-by: Roberth Strand <me@robstr.dev>