### PR TITLE
[WG Platforms] Whitepaper - Base framework

### DIFF
--- a/.github/workflows/publish-platforms-paper.yaml
+++ b/.github/workflows/publish-platforms-paper.yaml
@@ -1,0 +1,16 @@
+name: Publish Platforms Paper
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: platforms-whitepaper/index.bs
+          DESTINATION: cncf.github.io_tag-app-delivery/_posts/platforms-def.html
+          GH_PAGES_BRANCH: jekyll
+          TOOLCHAIN: bikeshed

--- a/platforms-whitepaper/v1alpha1/.gitignore
+++ b/platforms-whitepaper/v1alpha1/.gitignore
@@ -1,0 +1,1 @@
+index.html

--- a/platforms-whitepaper/v1alpha1/10-what-is-a-platform.md
+++ b/platforms-whitepaper/v1alpha1/10-what-is-a-platform.md
@@ -1,0 +1,3 @@
+## What a platform is
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/20-why-platforms.md
+++ b/platforms-whitepaper/v1alpha1/20-why-platforms.md
@@ -1,0 +1,3 @@
+## Why a platform is valuable
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/30-measure-platforms.md
+++ b/platforms-whitepaper/v1alpha1/30-measure-platforms.md
@@ -1,0 +1,3 @@
+## How to measure success of platforms
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/40-platform-attributes.md
+++ b/platforms-whitepaper/v1alpha1/40-platform-attributes.md
@@ -1,0 +1,3 @@
+## Attributes of platforms
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/50-platform-team-attributes.md
+++ b/platforms-whitepaper/v1alpha1/50-platform-team-attributes.md
@@ -1,0 +1,3 @@
+## Attributes of platform teams
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/60-platform-capabilities.md
+++ b/platforms-whitepaper/v1alpha1/60-platform-capabilities.md
@@ -1,0 +1,3 @@
+## Capabilities of platforms
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/README.md
+++ b/platforms-whitepaper/v1alpha1/README.md
@@ -1,0 +1,33 @@
+# Platforms whitepaper
+
+CNCF TAG App Delivery maintains and publishes this paper describing platforms
+for cloud-native computing to support project maintainers and cloud users in
+planning and designing such platforms.
+
+An initial v0.1 release is proposed for early January 2023 to be followed by
+ongoing updates and releases as appropriate.
+
+The paper is divided into several sections which are automatically merged for
+releases and reviews.
+
+## TODO
+
+1. adopt a document publishing framework that automatically merges sections and
+   publishes paper as Markdown and PDF
+1. create PRs for initial content for top-level sections
+1. add executive summary and ensure consistent voice
+1. publish with CNCF
+
+## Technical info
+
+The document is generated using
+[bikeshed](https://github.com/tabatkins/bikeshed), a tool also used by W3C and TC39.
+Follow [these instructions](https://tabatkins.github.io/bikeshed/#installing)
+to install `bikeshed`.
+
+Once installed, run `bikeshed` in this directory to generate an HTML doc, then
+open it in a browser.
+
+The document is generated and published to the TAG's blog site by the GitHub
+action at
+[`.github/workflows/publish-platforms-paper.yaml`](../.github/workflows/publish-platforms-paper.yaml)

--- a/platforms-whitepaper/v1alpha1/executive-summary.md
+++ b/platforms-whitepaper/v1alpha1/executive-summary.md
@@ -1,0 +1,3 @@
+## Executive Summary
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/glossary.md
+++ b/platforms-whitepaper/v1alpha1/glossary.md
@@ -1,0 +1,3 @@
+## Glossary
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/index.bs
+++ b/platforms-whitepaper/v1alpha1/index.bs
@@ -1,0 +1,22 @@
+<pre class='metadata'>
+Title: Platforms Definition
+Shortname: platforms-def
+Level: none
+Status: LD
+Group: CNCFTAGAppDelivery
+URL: http://cncf.github.io/tag-app-delivery/platforms-def
+Editor: Josh Gavant, Red Hat http://redhat.com/, jgavant@redhat.com, https://blog.joshgav.com/
+Editor: Abby Bangser, Syntasso http://www.syntasso.io/, abby@syntasso.io, https://cncf.github.io/tag-app-delivery
+Abstract: Describes what a platform is, the value it provides, and the attributes and capabilities it should include.
+</pre>
+
+<pre class='include'>path: executive-summary.md</pre>
+<pre class='include'>path: introduction.md</pre>
+<pre class='include'>path: 10-what-is-a-platform.md</pre>
+<pre class='include'>path: 20-why-platforms.md</pre>
+<pre class='include'>path: 30-measure-platforms.md</pre>
+<pre class='include'>path: 40-platform-attributes.md</pre>
+<pre class='include'>path: 50-platform-team-attributes.md</pre>
+<pre class='include'>path: 60-platform-capabilities.md</pre>
+<pre class='include'>path: glossary.md</pre>
+<pre class='include'>path: references.md</pre>

--- a/platforms-whitepaper/v1alpha1/introduction.md
+++ b/platforms-whitepaper/v1alpha1/introduction.md
@@ -1,0 +1,3 @@
+## Introduction
+
+// TODO

--- a/platforms-whitepaper/v1alpha1/references.md
+++ b/platforms-whitepaper/v1alpha1/references.md
@@ -1,0 +1,3 @@
+## References
+
+// TODO


### PR DESCRIPTION
Replaces #246. To suggest changes submit a PR to the `paper-framework` branch here.

This is a proposal for a framework to build and publish the "Platforms Definition" whitepaper from #246. Initial content is to be added from [the doc in progress](https://docs.google.com/document/d/1UDL3E5BqPyDdzV1wek9o8xR-nLJQXEEMU1qIMCgq5cI/), see #258, #259.

Note that the content PRs can be reviewed independently of this one; the content could be rendered in other ways too - for example, many other CNCF papers have been integrated via manual copy-and-paste.

This proposal suggests [bikeshed](https://github.com/tabatkins/bikeshed) to generate a complete HTML doc from a template and the section docs. You can try it by cloning this PR and running `bikeshed` within the paper's directory; then open the generated `index.html` in a browser to review.

bikeshed is actively maintained by W3C and used by them and TC39 already so it seems like a project CNCF can rely on and perhaps participate in.

This PR also includes and uses the [w3c/spec-prod](https://github.com/w3c/spec-prod) GitHub Action step to invoke bikeshed, generate the doc, and push it into the `jekyll` branch as a post. As a nice bonus, the generated doc is also available as an artifact after the Action runs for review. See an example in this run in my repo fork: <https://github.com/joshgav/tag-app-delivery/actions/runs/3699614235>. The action is currently configured to only be run on demand, not on PRs; we can adapt that as we go.