### PR TITLE
[TAG] Home page updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,48 @@
-# CNCF App Delivery TAG
+# CNCF TAG App Delivery
 
-The Application Delivery TAG focuses on delivering cloud-native applications which involves multiple phases including building, deploying, managing, and operating. Additionally, the TAG produces supporting material and best practices for end-users, and provides guidance and coordination for CNCF projects working within the SIG’s scope.
+TAG App Delivery focuses on enabling projects and initiatives related to
+delivering cloud-native applications, including building, deploying, managing,
+and operating them. The TAG produces guidance for and gathers feedback from
+cloud app users and developers and provides guidance and coordination to CNCF
+projects in the TAG's technical domains.
 
-See our full charter here: <https://github.com/cncf/toc/blob/main/tags/app-delivery.md>
-
-## Chairs
-
-Alois Reitbauer, Jennifer Strejevitch, Hongchao Deng
-
-## Tech Leads
-
-Alex Jones, Thomas Schuetz, Josh Gavant
+Full charter here: <https://github.com/cncf/toc/blob/main/tags/app-delivery.md>
 
 ## Community
 
-* Slack channel: #tag-app-delivery in CNCF workspace - <https://cloud-native.slack.com/messages/CL3SL0CP5>
+* Home page: <https://community.cncf.io/tag-app-delivery/>
+* Slack channel: [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5) in [CNCF Slack](https://slack.cncf.io/)
 * Mailing list: <https://lists.cncf.io/g/cncf-tag-app-delivery/topics>
 
 ## Meetings
 
-We have meetings every 1st and 3rd Wednesday of the month at 16:00 UTC [see in your local time](https://dateful.com/convert/utc?t=16).
+1st and 3rd Wednesday of each month at 16:00 UTC ([convert to your local
+time](https://dateful.com/convert/utc?t=16)).
+
+Meetings are listed on the [main CNCF calendar](https://www.cncf.io/calendar/)
+as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-delivery/).
 
 * Agenda and Notes: <https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#>
-* Zoom Meeting: <https://zoom.us/j/7276783015> Passcode=77777
+* Zoom Meeting: <https://zoom.us/j/7276783015>
+    * Passcode: 77777
 * Recordings of previous meetings: <https://www.youtube.com/playlist?list=PLj6h78yzYM2OHd1Ht3jiZuucWzvouAAci>
+
+## Leads
+
+- Alois Reitbauer (@AloisReitbauer) (Chair)
+- Jennifer Strejevitch (@Jenninha) (Chair)
+- Hongchao Deng (@hongchaodeng) (Chair)
+- Alex Jones (@alexsjones) (TL)
+- Thomas Schuetz (@thschue) (TL)
+- Josh Gavant (@joshgav) (TL)
 
 ## Working Groups
 
 The TAG has created the following working groups to investigate and discuss the following topics:
 
 | Working Group | Chairs            | Meeting Time                          |
-|---------------|------------------|---------------------------------------|
+|---------------|-------------------|---------------------------------------|
 | [Platforms](https://github.com/cncf/tag-app-delivery/tree/main/platforms-wg) | [platforms-wg/README.md#chairs](./platforms-wg/README.md#chairs) | [platforms-wg/README.md#meetings](./platforms-wg/README.md#meetings) |
-| [Air Gapped](https://github.com/cncf/tag-app-delivery/tree/main/air-gapped-wg)         |   | Inactive |
 | [GitOps](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg) | [gitops-wg/CHAIRS.md](./gitops-wg/CHAIRS.md) | [gitops-wg/README.md#meetings](./gitops-wg/README.md#meetings) |
+| [Air Gapped](https://github.com/cncf/tag-app-delivery/tree/main/air-gapped-wg)         |   | Inactive |
 | [Operator](https://github.com/cncf/tag-app-delivery/tree/main/operator-wg) | | Inactive |
-
-All meetings are on the public CNCF calendar: <https://www.cncf.io/calendar/>


### PR DESCRIPTION
- Added links to TAG pages on <https://community.cncf.io/>.
- Moved community and meetings sections higher on page
- Combined lists of leads, added GitHub handles
- Moved inactive WGs to last in WG list
- Clarifying edit of introductory paragraph (PTAL!)
