### PR TITLE
Integrate platform team challenges into general challenges

### DIFF
--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -278,7 +278,7 @@ To counter this, platform teams should include product managers from the start
 to share roadmaps, gather feedback and generally understand and represent the
 needs of platform users.
 
-However, Platform teams can easily be overloaded in their efforts to support many
+Additionally, Platform teams can easily be overloaded in their efforts to support many
 product teams simultaneously. Ways to reduce load on the platform team include
 the following:
 

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -267,7 +267,7 @@ of engaged and skillful app teams. Detailed feedback from such teams improves th
 first platform experiences; and people from those teams help champion and
 evangelize the platform to later adopters.
 
-Perhaps most important is to recognize that the success of a platform is
+Perhaps most important is to treat the platform as a customer-facing product and recognize that its success is
 directly dependent on the success of its users and products; and as such it's
 vital that platform teams partner with app teams and other users to prioritize,
 plan, implement and iterate on the platform's capabilities and user experiences.

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -288,13 +288,18 @@ stream teams (see the previous two paragraphs), presenting the platform team as
 a strategic partner of product teams in delivering value to customers.
 
 ## Enabling platform teams
-Another challenge for platform teams is the amount of cognitive load, when attempting
-to support multiple teams simultaneously.
 
-Ways to reduce load on the platform team include the following:
+It is clear from these challenges that platform teams are faced with a number of
+diverse responsibilities which lead to cognitive load. Just as with their
+application team counterparts, this challenge grows with the number and diversity
+of users and teams they need to support.
+
+It is important to focus the platform team's energy on the experience and
+capabilities that are unique to their specific business. Ways to reduce load on
+the platform team include the following:
 
 1. Use implementations from managed service providers where reasonable
-1. Use open source frameworks and toolkits for creating docs, templates and
+1. Leverage open source frameworks and toolkits for creating docs, templates and
    compositions for application team use
 1. Ensure platform teams are staffed appropriately for their domain and number
    of customers

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -259,14 +259,6 @@ following which implementers should keep in mind.
 1. Platform teams must seek support of enterprise leadership and show impact on
    value streams
 
-When adopting platforms, choosing the right capabilities and experiences to
-enable first, can be crucial. Capabilities that are frequently required and
-undifferentiated, like pipelines, databases and observability, may be a good
-place to start. Platform teams may also choose to focus first on a limited number
-of engaged and skillful app teams. Detailed feedback from such teams improves the
-first platform experiences; and people from those teams help champion and
-evangelize the platform to later adopters.
-
 Perhaps most important is to treat the platform as a customer-facing product and recognize that its success is
 directly dependent on the success of its users and products; and as such it's
 vital that platform teams partner with app teams and other users to prioritize,
@@ -277,6 +269,14 @@ resistance and resentment from their users and miss a lot of the promised value.
 To counter this, platform teams should include product managers from the start
 to share roadmaps, gather feedback and generally understand and represent the
 needs of platform users.
+
+When adopting platforms, choosing the right capabilities and experiences to
+enable first, can be crucial. Capabilities that are frequently required and
+undifferentiated, like pipelines, databases and observability, may be a good
+place to start. Platform teams may also choose to focus first on a limited number
+of engaged and skillful app teams. Detailed feedback from such teams improves the
+first platform experiences; and people from those teams help champion and
+evangelize the platform to later adopters.
 
 Additionally, Platform teams can easily be overloaded in their efforts to support many
 product teams simultaneously. Ways to reduce load on the platform team include

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -259,6 +259,14 @@ following which implementers should keep in mind.
 1. Platform teams must seek support of enterprise leadership and show impact on
    value streams
 
+When adopting platforms, choosing the right capabilities and experiences to
+enable first, can be crucial. Capabilities that are frequently required and
+undifferentiated, like pipelines, databases and observability, may be a good
+place to start. Platform teams may also choose to focus first on a limited number
+of engaged and skillful app teams. Detailed feedback from such teams improves the
+first platform experiences; and people from those teams help champion and
+evangelize the platform to later adopters.
+
 Perhaps most important is to recognize that the success of a platform is
 directly dependent on the success of its users and products; and as such it's
 vital that platform teams partner with app teams and other users to prioritize,
@@ -279,6 +287,7 @@ teams. Ways to reduce load on the platform team include the following:
 1. Ensure platform teams are staffed appropriately for their domain and number
    of customers
 
+<<<<<<< HEAD
 Another challenge when adopting platforms is choosing the right capabilities and
 experiences to enable first. Services that are frequently required and
 undifferentiated, like pipelines, databases and observability, may be a good
@@ -287,6 +296,8 @@ number of engaged and skillful app teams. Detailed feedback from such teams
 improves the first platform experiences; and people from those teams help
 champion and evangelize the platform to later adopters.
 
+=======
+>>>>>>> 60a9a86 (switch order, to keep all points about the platform team itself together)
 Finally, it's vital in large enterprises to quickly gain leadership support for
 platform teams. Many enterprise leaders perceive IT infrastructure as an expense
 quite disconnected from their primary value streams and may try to constrain

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -278,8 +278,9 @@ To counter this, platform teams should include product managers from the start
 to share roadmaps, gather feedback and generally understand and represent the
 needs of platform users.
 
-Platform teams can easily be overloaded in their efforts to support many product
-teams. Ways to reduce load on the platform team include the following:
+However, Platform teams can easily be overloaded in their efforts to support many
+product teams simultaneously. Ways to reduce load on the platform team include
+the following:
 
 1. Use implementations from managed service providers where reasonable
 1. Use open source frameworks and toolkits for creating docs, templates and

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -247,17 +247,6 @@ delivering department wide announcements, sharing engaging demos, and welcoming
 questions during regular office hours. The key here is to meet users where they
 are, and bring them on the journey to engage with and benefit from the platform.
 
-### Enabling platform teams
-
-Platform teams can easily be overloaded in their efforts to support many product
-teams. Ways to reduce load on the platform team include the following:
-
-1. Use implementations from managed service providers where reasonable
-1. Use open source frameworks and toolkits for creating docs, templates and
-   compositions for application team use
-1. Ensure platform teams are staffed appropriately for their domain and number
-   of customers
-
 ## Challenges with platforms
 
 While platforms promise lots of value, they also bring challenges like the
@@ -280,6 +269,15 @@ resistance and resentment from their users and miss a lot of the promised value.
 To counter this, platform teams should include product managers from the start
 to share roadmaps, gather feedback and generally understand and represent the
 needs of platform users.
+
+Platform teams can easily be overloaded in their efforts to support many product
+teams. Ways to reduce load on the platform team include the following:
+
+1. Use implementations from managed service providers where reasonable
+1. Use open source frameworks and toolkits for creating docs, templates and
+   compositions for application team use
+1. Ensure platform teams are staffed appropriately for their domain and number
+   of customers
 
 Another challenge when adopting platforms is choosing the right capabilities and
 experiences to enable first. Services that are frequently required and

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -259,16 +259,16 @@ following which implementers should keep in mind.
 1. Platform teams must seek support of enterprise leadership and show impact on
    value streams
 
-Perhaps most important is to treat the platform as a customer-facing product and recognize that its success is
-directly dependent on the success of its users and products; and as such it's
-vital that platform teams partner with app teams and other users to prioritize,
-plan, implement and iterate on the platform's capabilities and user experiences.
-Platform teams that release features and experiences without feedback or
-that rely on top-down mandates to achieve adoption are almost certain to find
-resistance and resentment from their users and miss a lot of the promised value.
-To counter this, platform teams should include product managers from the start
-to share roadmaps, gather feedback and generally understand and represent the
-needs of platform users.
+Perhaps most important is to treat the platform as a customer-facing product and
+recognize that its success is directly dependent on the success of its users and
+products; and as such it's vital that platform teams partner with app teams and
+other users to prioritize, plan, implement and iterate on the platform's
+capabilities and user experiences. Platform teams that release features and
+experiences without feedback or that rely on top-down mandates to achieve adoption
+are almost certain to find resistance and resentment from their users and miss a
+lot of the promised value. To counter this, platform teams should include product
+managers from the start to share roadmaps, gather feedback and generally understand
+and represent the needs of platform users.
 
 When adopting platforms, choosing the right capabilities and experiences to
 enable first, can be crucial. Capabilities that are frequently required and

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -278,27 +278,6 @@ of engaged and skillful app teams. Detailed feedback from such teams improves th
 first platform experiences; and people from those teams help champion and
 evangelize the platform to later adopters.
 
-Additionally, Platform teams can easily be overloaded in their efforts to support many
-product teams simultaneously. Ways to reduce load on the platform team include
-the following:
-
-1. Use implementations from managed service providers where reasonable
-1. Use open source frameworks and toolkits for creating docs, templates and
-   compositions for application team use
-1. Ensure platform teams are staffed appropriately for their domain and number
-   of customers
-
-<<<<<<< HEAD
-Another challenge when adopting platforms is choosing the right capabilities and
-experiences to enable first. Services that are frequently required and
-undifferentiated, like pipelines, databases and observability, may be a good
-place to start. Platform teams may also choose to focus first on a limited
-number of engaged and skillful app teams. Detailed feedback from such teams
-improves the first platform experiences; and people from those teams help
-champion and evangelize the platform to later adopters.
-
-=======
->>>>>>> 60a9a86 (switch order, to keep all points about the platform team itself together)
 Finally, it's vital in large enterprises to quickly gain leadership support for
 platform teams. Many enterprise leaders perceive IT infrastructure as an expense
 quite disconnected from their primary value streams and may try to constrain
@@ -307,6 +286,18 @@ unrealized promises and frustration. To mitigate this, platform teams need to
 demonstrate their direct impact on and relationships with product and value
 stream teams (see the previous two paragraphs), presenting the platform team as
 a strategic partner of product teams in delivering value to customers.
+
+## Enabling platform teams
+Another challenge for platform teams is the amount of cognitive load, when attempting
+to support multiple teams simultaneously.
+
+Ways to reduce load on the platform team include the following:
+
+1. Use implementations from managed service providers where reasonable
+1. Use open source frameworks and toolkits for creating docs, templates and
+   compositions for application team use
+1. Ensure platform teams are staffed appropriately for their domain and number
+   of customers
 
 ## How to measure the success of platforms
 


### PR DESCRIPTION
#276 #277
As discussed in the 01/17 WG platforms meeting, I have created a suggestion to move the "Enabling platform teams" section into "Challenges with platforms"