### PR TITLE
Add DevSpace to platforms whitepaper

### DIFF
--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -427,7 +427,7 @@ included in their platform.
   <tr>
     <td>Development environments and tools</td>
     <td>Provide tools to aid in editing, testing, and debugging code</td>
-    <td>devfile, Tilt, Skaffold, DevSpaces, Telepresense, Eclipse Che, VS, JetBrains, Eclipse</td>
+    <td>devfile, Tilt, Skaffold, DevSpace, DevSpaces, Telepresense, Eclipse Che, VS, JetBrains, Eclipse</td>
   </tr>
   <tr>
     <td>Accounting</td>


### PR DESCRIPTION
DevSpace definitely fits the "Development environments and tools" category, and it is [recently been accepted](https://docs.google.com/document/d/1jpoKT12jf2jTf-2EJSAl4iTdA7Aoj_uiI19qIaECNFc/edit#heading=h.uu0taobc1air) as CNCF sandbox project.

Signed-off-by: Oleg Matskiv <oleg.matskiv@gmail.com>