### PR TITLE
[Platforms] Add paragraph on TVP and "internal"

### DIFF
--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -81,17 +81,19 @@ identity access, infrastructure operations, and app lifecycle.
 
 ## What is a platform
 
-A platform is a layer that provides common supporting capabilities and services 
-for many applications and use cases. Such a platform provides consistent user 
-experiences for getting, using and managing its capabilities and services, 
-including Web portals and pages, scenario-specific code templates, automatable 
-APIs and command-line tools.
+A platform for cloud-native computing is an integrated collection of
+capabilities defined and presented according to the needs of the platform's
+users. It is a cross-cutting layer that ensures a consistent experience for
+acquiring and integrating typical capabilities and services for a broad set of
+applications and use cases. A good platform provides consistent user experiences
+for using and managing its capabilities and services, such as Web portals,
+project templates, and self-service APIs.
 
 According to Atlassian [[1]], "platform teams create capabilities that can be 
-used by numerous stream-aligned teams with little overhead.... platform teams 
-minimize resources and cognitive load of the stream-aligned team... platform 
-teams can create a cohesive experience that spans across different user 
-experiences or products."
+used by numerous stream-aligned [product] teams with little overhead....
+platform teams minimize resources and cognitive load of the stream-aligned
+[product] team... platform teams can create a cohesive experience that spans
+across different user experiences or products."
 
 According to Martin Fowler and Evan Bottcher [[2]], "a digital platform is a 
 foundation of self-service APIs, tools, services, knowledge and support which 
@@ -101,13 +103,13 @@ reduced coordination."
 
 The specific set of capabilities provided by a platform depends on the
 requirements of the platform's users. And while platforms _provide_ these
-required capabilities, it's critical to note that the platform team generally
-shouldn't _implement_ them themselves. Managed providers or dedicated teams
-should maintain implementations while the platform itself should be the thinnest
-consistent layer that meets an organization's requirements. For example, the
-simplest "platform" would be a wiki page with links to provision capabilities
-from providers. Some [[3]] have described this principle as seeking the
-"thinnest viable platform".
+required capabilities, it's critical to note that platform teams should not
+always _implement_ them themselves. Managed service providers or dedicated
+internal teams can maintain backing implementations while platforms are the
+thinnest reasonable layer that provides consistency for these implementations
+that meets an organization's requirements. For example, a very simple "platform"
+could be a wiki page with links to standard operating procedures to provision
+capabilities from providers, as described in [[3]].
 
 Because these platforms target no more and no less than an enterprise's internal
 users we often refer to them as _internal_ platforms.
@@ -126,39 +128,27 @@ applications and systems.
 
 At their most basic, internal platforms provide consistent experiences for
 acquiring and using individual services such as a pipeline runner, a database
-system or a secret store. Example use cases an enterprise can meet with a basic
-platform include the following:
+system or a secret store. As they mature internal platforms also offer
+_compositions_ of such services as self-serviceable templates for key scenarios
+like web application development or data analysis, aka MLOps.
 
-1. Developers of products and services can automatically provision runtime 
-   capabilities such as compute, storage, databases and service identity and 
-   immediately integrate and use those as part of their products
-1. Developers of products and services can automatically provision supporting 
-   services such as task runners, package registries, deployment orchestrators and 
-   observability systems to build, verify, operate and observe their products
-1. Operators of third-party products and services can automatically provision 
-   spaces and supporting services to deploy and use those third-party products and 
-   services
+Use cases an enterprise could meet with platforms might progress through the
+following:
 
-A more advanced internal platform also _composes_ capabilities into experiences
-and templates fit for key scenarios like web application development or data
-analysis. For example, an internal developer platform includes templates for
-provisioning complete development environments and could serve the following use
-cases:
-
-1. Developers of products or services can automatically request a complete 
-   development environment to support iterative research and development of new 
-   features. This includes spaces in relevant services such as task runners and 
-   artifact storage, membership in designated teams, and publication of connection 
-   info such as URLs and secrets.
-1. Developers of products or services can use scenario-specific code and 
-   configuration templates to rapidly bootstrap, develop and deliver new products 
-   and features
-1. Stakeholders in a product or service can observe system and user behavior in 
-   those products and services via instrumentation, dashboards and alerts
+1. Product developers can provision capabilities on demand and immediately use
+   them to run systems, such as compute, storage, databases or identities.
+1. Product developers can provision service spaces on demand and use them to run
+   pipelines and tasks, to store artifacts and configuration, and/or to collect
+   telemetry.
+1. Third-party software operators can provision dependencies on demand and run
+   that software.
+1. Product developers can provision complete environments from templates
+   combining run-time and development-time services required for specific
+   scenarios, such as web development or MLOps.
 
 By offering consistent, compliant experiences for individual capabilities or
-sets of them, internal platforms make it easier and more efficient for their
-users to deliver valuable products.
+sets of them, internal platforms ultimately make it easier and more efficient
+for their users to deliver valuable products.
 
 [1]: https://www.atlassian.com/devops/frameworks/team-topologies
 [2]: https://martinfowler.com/articles/talk-about-platforms.html
@@ -224,38 +214,42 @@ those experiences meet requirements.
 
 Following are jobs a platform team should be responsible for:
 
-1. Research platform user requirements
-1. Manage and develop interfaces for capabilities and services - portals, APIs,
-   docs and templates, CLIs
-1. Market, evangelize and advocate for platform usage
+1. Research platform user requirements and plan feature roadmap
+1. Market, evangelize and advocate for the platform's proposed values
+1. Manage and develop interfaces for using and observing capabilities and
+   services, including portals, APIs, documentation and templates, and CLI tools
 
 Most importantly, platform teams must learn about the requirements of platform
-users \[1\] to inform and continuously improve capabilities and interfaces offered
-by their platform. Ways to learn about user requirements include user
-interviews, interactive hackathons, issue trackers and surveys, and direct
-observation of usage through observability tools. For example, a platform team
-could publish a form for users to submit feature requests; and conduct periodic
-roadmap meetings to share upcoming features and gather feedback.
+users to inform and continuously improve capabilities and interfaces offered by
+their platform. Ways to learn about user requirements include user interviews,
+interactive hackathons, issue trackers and surveys, and direct observation of
+usage through observability tools. For example, a platform team could publish a
+form for users to submit feature requests; and conduct periodic roadmap meetings
+to share upcoming features and gather feedback.
+
+Inbound feedback and thoughtful design is one side of product delivery; the
+other side is outbound marketing and advocacy. If the platform is truly built to
+user requirements those users will be excited to use the provided capabilities.
+Some ways a platform team can enable user adoption is through internal marketing
+activities including broad announcements, engaging demos, and regular feedback
+and communication sessions.  The key here is to meet users where they are and
+bring them on a journey to engage with and benefit from the platform.
 
 A platform team doesn't necessarily run compute, network, storage or other
-services, and in fact an internal platform should be as thin as viable as
-described above. A platform team instead is most responsible for the
-_interfaces_ \[2\] (GUI, CLI, API) and user experiences with those services. For
-example, a Web portal page might describe and even offer a button to provision
-an identity for an app; while the implementation of that capability might be via
-a cloud-hosted identity service.  An internal platform team may manage the web
-page and user-facing API, but not necessarily the implementation.
+services. In fact an internal platform should rely on _externally_-provided
+services and capabilities as much as possible; platform teams should build and
+maintain their own capabilities only when they're not available elsewhere from
+managed providers or internal infrastructure teams. Instead, platform teams are
+most responsible for the _interfaces_ (i.e., GUI, CLI, and API) and user
+experiences for the services and capabilities their platform makes available.
 
-Earlier it was stated that an internal platform should be treated as a product.
-Specifically, the platform should be continuously improved based on user
-requirements and optional to use (see: platform attributes #1 and #8). While
-research and design is one side of product delivery, the other side is marketing
-and advocacy \[3\]. If the platform is truly being built to user requirements,
-people should be excited to use the provided capabilities. Some ways a platform
-team can help adoptions is through internal marketing activities including
-delivering department wide announcements, sharing engaging demos, and welcoming
-questions during regular office hours. The key here is to meet users where they
-are, and bring them on the journey to engage with and benefit from the platform.
+For example, a Web page in a platform might describe and even offer a button to
+provision an identity for an app; while the implementation of that capability
+might be via a cloud-hosted identity service. An internal platform team may
+manage the web page and an API, but not the actual service implementation.
+Platform teams should consider creating and maintaining their own capabilities
+only when a required capability is not available elsewhere.
+
 
 ## Challenges with platforms
 

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -99,19 +99,35 @@ are arranged as a compelling internal product. Autonomous delivery teams can
 make use of the platform to deliver product features at a higher pace, with 
 reduced coordination."
 
-Platforms are particularly relevant for cloud-native computing, which typically 
-separates supporting capabilities from application-specific logic more than 
-previous paradigms. In such environments resources like databases and object 
-stores, message queues and brokers, observability collectors and dashboards, 
-user directories and authentication systems, task runners and reconcilers and 
-more are managed independently and integrated into applications running in 
-containers and machines. A platform for cloud-native computing provides these to 
-many teams in ways that make them easy to integrate in applications and systems.
+The specific set of capabilities provided by a platform depends on the
+requirements of the platform's users. And while platforms _provide_ these
+required capabilities, it's critical to note that the platform team generally
+shouldn't _implement_ them themselves. Managed providers or dedicated teams
+should maintain implementations while the platform itself should be the thinnest
+consistent layer that meets an organization's requirements. For example, the
+simplest "platform" would be a wiki page with links to provision capabilities
+from providers. Some [[3]] have described this principle as seeking the
+"thinnest viable platform".
 
-At its most basic, a platform provides consistent experiences to application 
-developers for acquiring and using individual services such as a database system 
-or a secret store. Example use cases an enterprise can meet with a basic platform 
-include the following:
+Because these platforms target no more and no less than an enterprise's internal
+users we often refer to them as _internal_ platforms.
+
+Platforms are particularly relevant for cloud-native architectures because these
+separate supporting capabilities from application-specific logic more than
+previous paradigms. In cloud-like environments resources and capabilities are
+often managed independently and integrated with custom business components; such
+resources may include databases and object stores, message queues and brokers,
+observability collectors and dashboards, user directories and authentication
+systems, task runners and reconcilers and more. An internal platform provides
+these to enterprise teams in ways that make them easy to integrate in their
+applications and systems.
+
+### Platform maturity
+
+At their most basic, internal platforms provide consistent experiences for
+acquiring and using individual services such as a pipeline runner, a database
+system or a secret store. Example use cases an enterprise can meet with a basic
+platform include the following:
 
 1. Developers of products and services can automatically provision runtime 
    capabilities such as compute, storage, databases and service identity and 
@@ -123,10 +139,11 @@ include the following:
    spaces and supporting services to deploy and use those third-party products and 
    services
 
-A more advanced platform also _composes_ these capabilities into experiences and 
-templates fit for key scenarios like web application development or data analysis. 
-For example, an application developer platform can include templates for provisioning 
-complete development environments and could serve the following use cases:
+A more advanced internal platform also _composes_ capabilities into experiences
+and templates fit for key scenarios like web application development or data
+analysis. For example, an internal developer platform includes templates for
+provisioning complete development environments and could serve the following use
+cases:
 
 1. Developers of products or services can automatically request a complete 
    development environment to support iterative research and development of new 
@@ -139,18 +156,13 @@ complete development environments and could serve the following use cases:
 1. Stakeholders in a product or service can observe system and user behavior in 
    those products and services via instrumentation, dashboards and alerts
 
-A platform is bespoke to an organisation, supporting a unique set of users and 
-business needs. While application developement and delivery is often the first 
-capability a platform supports, it is important to focus on the individual needs of 
-the organization which often surfaces additional opportunities to optimise through 
-a platform offering. Some examples can include data operations, user management, and 
-incident management.
-
-By offering consistent experiences for individual and/or scenario-oriented sets 
-of capabilities, platforms make it easy for their users to deliver valuable products.
+By offering consistent, compliant experiences for individual capabilities or
+sets of them, internal platforms make it easier and more efficient for their
+users to deliver valuable products.
 
 [1]: https://www.atlassian.com/devops/frameworks/team-topologies
 [2]: https://martinfowler.com/articles/talk-about-platforms.html
+[3]: https://teamtopologies.com/key-concepts-content/what-is-a-thinnest-viable-platform-tvp
 
 ## Attributes of platforms
 
@@ -226,14 +238,15 @@ could publish a form for users to submit feature requests; and conduct periodic
 roadmap meetings to share upcoming features and gather feedback.
 
 A platform team doesn't necessarily run compute, network, storage or other
-services. Rather they own the interfaces \[2\] (GUI, CLI, API) and user
-experiences with those services. For example, a Web portal page might describe
-and even offer a button to provision an identity for an app; while the
-implementation of that capability might be via a cloud-hosted identity service.
-A platform team owns the web page and user-facing API, but not necessarily the
-implementation.
+services, and in fact an internal platform should be as thin as viable as
+described above. A platform team instead is most responsible for the
+_interfaces_ \[2\] (GUI, CLI, API) and user experiences with those services. For
+example, a Web portal page might describe and even offer a button to provision
+an identity for an app; while the implementation of that capability might be via
+a cloud-hosted identity service.  An internal platform team may manage the web
+page and user-facing API, but not necessarily the implementation.
 
-Earlier it was stated that a platform should be treated as a product.
+Earlier it was stated that an internal platform should be treated as a product.
 Specifically, the platform should be continuously improved based on user
 requirements and optional to use (see: platform attributes #1 and #8). While
 research and design is one side of product delivery, the other side is marketing
@@ -295,7 +308,8 @@ It is important to focus the platform team's energy on the experience and
 capabilities that are unique to their specific business. Ways to reduce load on
 the platform team include the following:
 
-1. Use implementations from managed service providers where reasonable
+1. Seek to build the thinnest viable platform layer over implementations from
+   managed providers
 1. Leverage open source frameworks and toolkits for creating docs, templates and
    compositions for application team use
 1. Ensure platform teams are staffed appropriately for their domain and number

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -224,8 +224,8 @@ users to inform and continuously improve capabilities and interfaces offered by
 their platform. Ways to learn about user requirements include user interviews,
 interactive hackathons, issue trackers and surveys, and direct observation of
 usage through observability tools. For example, a platform team could publish a
-form for users to submit feature requests; and conduct periodic roadmap meetings
-to share upcoming features and gather feedback.
+form for users to submit feature requests, lead roadmap meetings
+to share upcoming features and review users' usage patterns to set priorities.
 
 Inbound feedback and thoughtful design is one side of product delivery; the
 other side is outbound marketing and advocacy. If the platform is truly built to
@@ -247,8 +247,8 @@ For example, a Web page in a platform might describe and even offer a button to
 provision an identity for an app; while the implementation of that capability
 might be via a cloud-hosted identity service. An internal platform team may
 manage the web page and an API, but not the actual service implementation.
-Platform teams should consider creating and maintaining their own capabilities
-only when a required capability is not available elsewhere.
+Platform teams should usually consider creating and maintaining their own
+capabilities only when a required capability is not available elsewhere.
 
 
 ## Challenges with platforms
@@ -373,7 +373,7 @@ true measure of the success of a platform.
 
 As described earlier, a platform for cloud-native computing offers and composes
 capabilities and services from many supporting providers. These providers may be
-other teams within the same enterprise or third parties like "cloud" service
+other teams within the same enterprise or third parties like cloud service
 providers. Platforms enable use of the capabilities and services from these
 providers by wrapping them with consistent web portals, documentation, code
 templates, and programmable APIs and tools. 


### PR DESCRIPTION
This PR proposes adding a paragraph to the "What is a Platform?" section emphasizing that platform builders should start with the Thinnest Viable Platform ([TVP](https://github.com/TeamTopologies/Thinnest-Viable-Platform-examples)) and focus on the most critical needs of their users. Per @Abhinav-rafay's suggestion in #301 it segues into that with a sentence saying the platform's purpose is to meet the needs of its users.

Folks have shared that putting this idea early in the paper is important so that readers don't come away thinking _everyone_ must build _all_ the capabilities listed for their platforms. We may clarify the Capabilities section along these lines too.

This PR also adds a sentence explaining why we sometimes use the term "internal" platforms.

Related: https://github.com/cncf/tag-app-delivery/issues/273