### PR TITLE
[Platforms] Clean refs

### DIFF
--- a/platforms-whitepaper/v1alpha1/links.md
+++ b/platforms-whitepaper/v1alpha1/links.md
@@ -1,0 +1,41 @@
+# Links
+
+This is a list of articles, books, talks and more about cloud-native computing
+platforms. These have informed our opinions and are maintained to help inform
+others too.
+
+- https://slack.engineering/mobile-developer-experience-at-slack/
+- https://platformengineering.org/talks-library/netflix-platform-console-to-unify-engineering-experience
+- https://platformengineering.org/blog/product-management-for-internal-developer-platforms
+- https://humanitec.com/whitepapers/state-of-platform-engineering-report-volume-1
+- https://www.gartner.com/en/articles/what-is-platform-engineering
+- https://thenewstack.io/platform-engineering-infrastructure-meets-dev-experience/
+- https://netflixtechblog.com/full-cycle-developers-at-netflix-a08c31f83249
+- https://thenewstack.io/vmware-targets-the-platform-engineer/
+- https://platformcon.com/
+- https://thenewstack.io/architecture-and-design-considerations-for-platform-engineering-teams/
+- https://rafay.co/the-kubernetes-current/architecture-and-design-considerations-for-platform-engineering-teams
+- https://medium.com/@michael.roy.galloway/your-platform-org-needs-a-purpose-heres-how-to-find-it-64874b082d80
+- https://www.infoq.com/news/2022/10/platform-devops-summary/
+- https://salaboy.com/2022/09/29/the-challenges-of-platform-building-on-top-of-kubernetes-1-4/
+- https://engineering.atspotify.com/2020/08/how-we-improved-developer-productivity-for-our-devops-teams/
+- https://cloud.redhat.com/blog/designing-golden-paths
+- https://blog.container-solutions.com/how-to-design-an-internal-developer-platform
+- https://www.honeycomb.io/blog/future-ops-platform-engineering
+- https://www.getambassador.io/resources/rise-of-cloud-native-engineering-organizations/
+- https://blog.getambassador.io/the-developer-experience-and-the-role-of-the-sre-are-changing-heres-how-6003a12571c4
+- https://www.infoworld.com/article/3639050/complexity-is-killing-software-developers.html
+- https://www.xenonstack.com/insights/internal-developer-platform
+- https://engineering.atspotify.com/2020/08/how-we-use-golden-paths-to-solve-fragmentation-in-our-software-ecosystem
+- https://backstage.spotify.com/blog/measuring-backstage-success-at-spotify/
+- https://martinfowler.com/articles/talk-about-platforms.html
+- https://www.infoq.com/articles/platform-engineering-roadmap/
+- https://github.com/adobe-platform/Adobe-Workshop-ArgoCon2022/blob/main/IDP-Capabilities.md
+- https://humanitec.com/blog/top-10-fallacies-in-platform-engineering
+- https://thenewstack.io/platform-engineering-challenges-and-solutions/
+- https://www.cloudknit.io/blog/platform-engineering
+- https://www.cloudknit.io/blog/platform-engineering-challenges-and-solutions
+- https://blog.getambassador.io/top-8-mistakes-made-by-platform-engineers-d892c7448684
+- https://www.hashicorp.com/resources/non-technical-challenges-of-platform-engineering
+- https://www.gartner.com/en/documents/4010078
+- https://reprints2.forrester.com/#/assets/2/108/RES176392/report

--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -153,10 +153,6 @@ By offering consistent, compliant experiences for individual capabilities or
 sets of them, internal platforms ultimately make it easier and more efficient
 for their users to deliver valuable products.
 
-[1]: https://www.atlassian.com/devops/frameworks/team-topologies
-[2]: https://martinfowler.com/articles/talk-about-platforms.html
-[3]: https://teamtopologies.com/key-concepts-content/what-is-a-thinnest-viable-platform-tvp
-
 ## Attributes of platforms
 
 After defining what a platform is and why an organization might want to build one,
@@ -368,9 +364,6 @@ other IT capabilities with an enterprise's value streams - its products. And so
 ultimately the success of an organization's products and applications are the
 true measure of the success of a platform.
 
-[3]: https://queue.acm.org/detail.cfm?id=3454124
-[4]: https://cloud.google.com/blog/products/devops-sre/the-2019-accelerate-state-of-devops-elite-performance-productivity-and-scaling
-
 ## Capabilities of platforms
 
 As we've described, a platform for cloud-native computing offers and composes
@@ -541,40 +534,10 @@ by Matthew Skelton and Manuel Pais. The definition says: "A TVP is a careful bal
 keeping the platform small and ensuring that the platform is helping to accelerate and simplify 
 software delivery for teams building on the platform."
 
-## Bibliography
+<!-- ## Footnotes -->
 
-- https://slack.engineering/mobile-developer-experience-at-slack/
-- https://platformengineering.org/talks-library/netflix-platform-console-to-unify-engineering-experience
-- https://platformengineering.org/blog/product-management-for-internal-developer-platforms
-- https://humanitec.com/whitepapers/state-of-platform-engineering-report-volume-1
-- https://www.gartner.com/en/articles/what-is-platform-engineering
-- https://thenewstack.io/platform-engineering-infrastructure-meets-dev-experience/
-- https://netflixtechblog.com/full-cycle-developers-at-netflix-a08c31f83249
-- https://thenewstack.io/vmware-targets-the-platform-engineer/
-- https://platformcon.com/
-- https://thenewstack.io/architecture-and-design-considerations-for-platform-engineering-teams/
-- https://rafay.co/the-kubernetes-current/architecture-and-design-considerations-for-platform-engineering-teams
-- https://medium.com/@michael.roy.galloway/your-platform-org-needs-a-purpose-heres-how-to-find-it-64874b082d80
-- https://www.infoq.com/news/2022/10/platform-devops-summary/
-- https://salaboy.com/2022/09/29/the-challenges-of-platform-building-on-top-of-kubernetes-1-4/
-- https://engineering.atspotify.com/2020/08/how-we-improved-developer-productivity-for-our-devops-teams/
-- https://cloud.redhat.com/blog/designing-golden-paths
-- https://blog.container-solutions.com/how-to-design-an-internal-developer-platform
-- https://www.honeycomb.io/blog/future-ops-platform-engineering
-- https://www.getambassador.io/resources/rise-of-cloud-native-engineering-organizations/
-- https://blog.getambassador.io/the-developer-experience-and-the-role-of-the-sre-are-changing-heres-how-6003a12571c4
-- https://www.infoworld.com/article/3639050/complexity-is-killing-software-developers.html
-- https://www.xenonstack.com/insights/internal-developer-platform
-- https://engineering.atspotify.com/2020/08/how-we-use-golden-paths-to-solve-fragmentation-in-our-software-ecosystem
-- https://backstage.spotify.com/blog/measuring-backstage-success-at-spotify/
-- https://martinfowler.com/articles/talk-about-platforms.html
-- https://www.infoq.com/articles/platform-engineering-roadmap/
-- https://github.com/adobe-platform/Adobe-Workshop-ArgoCon2022/blob/main/IDP-Capabilities.md
-- https://humanitec.com/blog/top-10-fallacies-in-platform-engineering
-- https://thenewstack.io/platform-engineering-challenges-and-solutions/
-- https://www.cloudknit.io/blog/platform-engineering
-- https://www.cloudknit.io/blog/platform-engineering-challenges-and-solutions
-- https://blog.getambassador.io/top-8-mistakes-made-by-platform-engineers-d892c7448684
-- https://www.hashicorp.com/resources/non-technical-challenges-of-platform-engineering
-- https://www.gartner.com/en/documents/4010078
-- https://reprints2.forrester.com/#/assets/2/108/RES176392/report
+[1]: https://www.atlassian.com/devops/frameworks/team-topologies
+[2]: https://martinfowler.com/articles/talk-about-platforms.html
+[3]: https://teamtopologies.com/key-concepts-content/what-is-a-thinnest-viable-platform-tvp
+[4]: https://queue.acm.org/detail.cfm?id=3454124
+[5]: https://cloud.google.com/blog/products/devops-sre/the-2019-accelerate-state-of-devops-elite-performance-productivity-and-scaling


### PR DESCRIPTION
This proposes:
- Move list of links from end of whitepaper to separate doc. Let's think about if/how we maintain it going forward - should it be a sort of "awesome list" for platform research?
- Consolidate footnotes and put at bottom of paper.

With this we'll also be able to more easily consider and add other footnotes.