### PR TITLE
add kubevela as one of the example project in platform whitepaper

### DIFF
--- a/platforms-whitepaper/v1alpha1/paper.md
+++ b/platforms-whitepaper/v1alpha1/paper.md
@@ -429,7 +429,7 @@ relating it to existing CNCF or CDF projects.
   <tr>
     <td>APIs for automatically provisioning capabilities</td>
     <td>Structured formats for automatically creating, updating, deleting and observing capabilities.</td>
-    <td>Kubernetes, Crossplane, Operator Framework, Helm</td>
+    <td>Kubernetes, Crossplane, Operator Framework, Helm, KubeVela</td>
   </tr>
   <tr>
     <td>Golden path templates and docs</td>


### PR DESCRIPTION
KubeVela is a typical project for platform engineering, it can glue multiple capabilities together and provide an application-centric API. If we can mention this project, the platform whitepaper can be more accurate. Thanks.