### PR TITLE
[TAG] Add custom domain name for our site

### DIFF
--- a/cncf.github.io_tag-app-delivery/CNAME
+++ b/cncf.github.io_tag-app-delivery/CNAME
@@ -1,0 +1,1 @@
+appdelivery.cncf.io


### PR DESCRIPTION
Adds a CNAME record associating our site with the domain name `appdelivery.cncf.io` following instructions from GitHub [here](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors).