### PR TITLE
(fix) typo

### DIFF
--- a/operator-whitepaper/v1/Operator-WhitePaper_v1-0.md
+++ b/operator-whitepaper/v1/Operator-WhitePaper_v1-0.md
@@ -861,7 +861,7 @@ Operators are programs that can be written in any language of choice.
 This works because Kubernetes provides a REST API that allows
 communication with clients using lightweight protocols such as HTTP.
 Consequently, software developers can write Operators in their preferred
-programming language as long as long as the REST API specifications are
+programming language as long as the REST API specifications are
 followed.
 
 However, if developers are free to choose their programming language,


### PR DESCRIPTION
as long as long as -> as long as 
: I'm not sure it is the intended sentence. but I think it is typo. 