### PR TITLE
fix pdf link in whitepaper

### DIFF
--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -1,6 +1,6 @@
 ---
 title:  "CNCF Platforms White Paper"
-pdf: https://github.com/cncf/tag-app-delivery/raw/main/platforms-whitepaper/v1/assets/platforms-def-latest.pdf
+pdf: https://github.com/cncf/tag-app-delivery/raw/main/platforms-whitepaper/v1/assets/platforms-def-v1.0.pdf
 version_info: https://github.com/cncf/tag-app-delivery/tree/main/platforms-whitepaper/README.md
 description: "This paper intends to support enterprise leaders, enterprise architects and platform team leaders to advocate for, investigate and plan internal platforms for cloud computing. We believe platforms significantly impact enterprises' actual value streams, but only indirectly, so leadership consensus and support is vital to the long-term sustainability and success of platform teams. In this paper we'll enable that support by discussing what the value of platforms is, how to measure it, and how to implement platform teams that maximize it."
 ---


### PR DESCRIPTION
PDF link should point to v1.0 for now.