### PR TITLE
add WG Artifacts basic README

### DIFF
--- a/artifacts-wg/README.md
+++ b/artifacts-wg/README.md
@@ -1,1 +1,23 @@
 # Artifacts WG
+
+The [charter](./charter/charter.md) describes the goals and activites of this group.
+
+To contribute please join our Slack channel and/or biweekly meetings.
+
+#wg-artifacts Slack channel: <https://cloud-native.slack.com/archives/C04UQDWS4M7>. Get an invite at <https://slack.cncf.io/>
+
+## Chairs
+
+- TBD
+- TBD
+
+
+## Meetings
+
+* Meeting schedule: 2nd and 4th Friday of each month at [1700 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20221213T170000&p1=1440)
+    * [2nd Friday](https://calendar.google.com/calendar/u/0/r/week/2023/7/14?eid=MGRnMGdvMDAzaGRqbHQzcWZhYWhhYjI5Z2tfMjAyMzA3MTRUMTcwMDAwWiBsaW51eGZvdW5kYXRpb24ub3JnX281YXZqbHZ0MmNhZTlicTdhOTVlbWM0NzQwQGc)
+    * [4th Friday](https://calendar.google.com/calendar/u/0/r/week/2023/7/28?eid=Mzc1MzAxMDkyMmdraWs4cjJkMzVyMGdhaWFfMjAyMzA3MjhUMTcwMDAwWiBsaW51eGZvdW5kYXRpb24ub3JnX281YXZqbHZ0MmNhZTlicTdhOTVlbWM0NzQwQGc)
+    * [Full CNCF calendar](https://calendar.cncf.io/)
+* Zoom: https://zoom.us/j/7276783015?pwd=R0RJMkRzQ1ZjcmE0WERGcTJTOEVyUT09 
+    * Passcode: 77777
+* Agendas and notes: <https://docs.google.com/document/d/1E7iKPOuyA1jxPe8vDG8aPd8jtnCEbpDpCifXDvDCnA0/edit>


### PR DESCRIPTION
This addresses one of the tasks in #417 and unblocks us from implementing #420.

README format is simply copied from the Platforms README.