### PR TITLE
[Artifacts] add WG Artifacts chairs to README

### DIFF
--- a/artifacts-wg/README.md
+++ b/artifacts-wg/README.md
@@ -8,9 +8,8 @@ To contribute please join our Slack channel and/or biweekly meetings.
 
 ## Chairs
 
-- TBD
-- TBD
-
+- Alex Flom ([@afflom](https://github.com/afflom))
+- Ramkumar Chinchani ([@rchincha](https://github.com/rchincha))
 
 ## Meetings
 

--- a/artifacts-wg/charter/README.md
+++ b/artifacts-wg/charter/README.md
@@ -1,0 +1,1 @@
+./charter.md


### PR DESCRIPTION
- adds @afflom as chair of WG Artifacts
- adds @rchincha as chair of WG Artifacts

closes #420 
closes #427

Please don't merge till WG Artifacts finalizes these elections, probably by its [next meeting this Friday July 28](https://community.cncf.io/events/details/cncf-tag-app-delivery-presents-wg-artifacts-project-meeting-2023-07-28/).

This PR also adds a symlink to the charter named "README.md" so that GitHub will automatically render it when someone browses to the directory.