### PR TITLE
feat: update permissions and documentation for chair transition

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -17,28 +17,27 @@ repository:
   # role. If there are questions, please contact one of the chairs.
 collaborators:
   # TOC Liasons
-  - username: cdavisafc
+  - username: kgamanji
     permission: admin
 
-  - username: resouer
+  - username: justincormack
     permission: admin
 
-
-  # SIG Chairs 
+  # TAG Chairs
   - username: AloisReitbauer
     permission: admin
 
-  - username: Jenniferstrej
+  - username: thschue
     permission: admin
     
-  - username: hongchaodeng
+  - username: joshgav
     permission: admin
 
   # Tech Leads
-    
   - username: AlexsJones
     permission: push
-    
-  - username: thschue
+
+  - username: lianmakesthings
     permission: push
+
     

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,14 +16,14 @@ repository:
   # a specific role, and we trust these individuals to act according to their
   # role. If there are questions, please contact one of the chairs.
 collaborators:
-  # TOC Liasons
+  # TOC Liasons (all have admin access)
   - username: kgamanji
     permission: admin
 
   - username: justincormack
     permission: admin
 
-  # TAG Chairs
+  # TAG Chairs (all have admin access)
   - username: AloisReitbauer
     permission: admin
 
@@ -33,11 +33,34 @@ collaborators:
   - username: joshgav
     permission: admin
 
-  # Tech Leads
+  # Tech Leads (all have maintain access)
   - username: AlexsJones
-    permission: push
+    permission: maintain
 
   - username: lianmakesthings
+    permission: maintain
+
+  # GitOps WG Chairs (all have push access)
+  - username: todaywasawesome
+    permission: push
+
+  - username: scottrigby
+    permission: push
+
+  - username: chris-short
+    permission: push
+
+  # Platforms WG Chairs (all have push access)
+  - username: roberthstrand
+    permission: push
+
+  - username: abangser
+    permission: push
+
+  # Artifacts WG Chairs (all have push access)
+  - username: afflom
+    permission: push
+  - username: rchincha
     permission: push
 
     

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,13 +8,13 @@
 #
 # Unless a later match takes precedence, these owners will be requested for
 # review when someone opens a pull request.
-*   @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings
+*   @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings @kgamanji @justincormack
 
 # Platforms WG
-/platforms-wg/ @AlexsJones @thschue @roberthstrand @joshgav
+/platforms-wg/ @abangser @roberthstrand @joshgav
 
 # GitOps WG
-/gitops-wg/ @todaywasawesome @chris-short @murillodigital @scottrigby @christianh814 @JaimeMagiera @niklasmtj @williamcaban @roberthstrand
+/gitops-wg/ @todaywasawesome @chris-short @scottrigby
 
 # Artifacts WG
 /artifacts-wg/ @afflom @rchincha

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,10 +8,7 @@
 #
 # Unless a later match takes precedence, these owners will be requested for
 # review when someone opens a pull request.
-*   @AloisReitbauer @Jenniferstrej @hongchaodeng @AlexsJones @thschue @joshgav
-
-# Operator Working Group
-/operator-wg/ @Jenniferstrej @OmerKahani @thschue
+*   @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings
 
 # Platforms WG
 /platforms-wg/ @AlexsJones @thschue @roberthstrand @joshgav

--- a/README.md
+++ b/README.md
@@ -29,12 +29,19 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 ## Leads
 
-- Alois Reitbauer (@AloisReitbauer) (Chair)
-- Jennifer Strejevitch (@Jenninha) (Chair)
-- Hongchao Deng (@hongchaodeng) (Chair)
+- Alois Reitbauer (@AloisReitbauer) (Co-Chair, Term: 2023/09/01 - 2025/08/31)
+- Josh Gavant (@joshgav) (Co-Chair, Term: 2023/09/01 - 2025/08/31)
+- Thomas Schuetz (@thschue) (Co-Chair, Term: 2021/09/01 - 2023/08/31)
 - Alex Jones (@alexsjones) (TL)
-- Thomas Schuetz (@thschue) (TL)
-- Josh Gavant (@joshgav) (TL)
+- Lian Li (@lianmakesthings) (TL)
+
+## TOC Liaisons
+- Katie Gamanji (@kgamanji)
+- Justin Cormack (@justincormack)
+
+## Emeritus Leads
+- Jennifer Strejevitch (@Jenninha)
+- Hongchao Deng (@hongchaodeng)
 
 ## Working Groups
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 ## Leads
 
-- Alois Reitbauer (@AloisReitbauer) (Co-Chair, Term: 2023/09/01 - 2025/08/31)
-- Josh Gavant (@joshgav) (Co-Chair, Term: 2023/09/01 - 2025/08/31)
-- Thomas Schuetz (@thschue) (Co-Chair, Term: 2021/09/01 - 2023/08/31)
+- Alois Reitbauer (@AloisReitbauer) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
+- Josh Gavant (@joshgav) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
+- Thomas Schuetz (@thschue) (Co-Chair, Term: 2023/08/30 - 2023/08/29)
 - Alex Jones (@alexsjones) (TL)
 - Lian Li (@lianmakesthings) (TL)
 
@@ -47,9 +47,9 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 The TAG has created the following working groups to investigate and discuss the following topics:
 
-| Working Group | Chairs            | Meeting Time                          |
-|---------------|-------------------|---------------------------------------|
-| [Platforms](https://github.com/cncf/tag-app-delivery/tree/main/platforms-wg) | [platforms-wg/README.md#chairs](./platforms-wg/README.md#chairs) | [platforms-wg/README.md#meetings](./platforms-wg/README.md#meetings) |
-| [GitOps](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg) | [gitops-wg/CHAIRS.md](./gitops-wg/CHAIRS.md) | [gitops-wg/README.md#meetings](./gitops-wg/README.md#meetings) |
-| [Air Gapped](https://github.com/cncf/tag-app-delivery/tree/main/air-gapped-wg)         |   | Inactive |
-| [Operator](https://github.com/cncf/tag-app-delivery/tree/main/operator-wg) | | Inactive |
+| Working Group                                                                  | Chairs                                                           | Meeting Time                                                         |
+|--------------------------------------------------------------------------------|------------------------------------------------------------------|----------------------------------------------------------------------|
+| [Platforms](https://github.com/cncf/tag-app-delivery/tree/main/platforms-wg)   | [platforms-wg/README.md#chairs](./platforms-wg/README.md#chairs) | [platforms-wg/README.md#meetings](./platforms-wg/README.md#meetings) |
+| [GitOps](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg)         | [gitops-wg/CHAIRS.md](./gitops-wg/CHAIRS.md)                     | [gitops-wg/README.md#meetings](./gitops-wg/README.md#meetings)       |
+| [Air Gapped](https://github.com/cncf/tag-app-delivery/tree/main/air-gapped-wg) |                                                                  | Inactive                                                             |
+| [Operator](https://github.com/cncf/tag-app-delivery/tree/main/operator-wg)     |                                                                  | Inactive                                                             |


### PR DESCRIPTION
# This PR
* Adds @joshgav and @thschue as chairs
* Adapts permissions in the TAG repo to the current roles