### PR TITLE
feat: add artifacts-wg to website

### DIFF
--- a/website/assets/content/artifacts-wg/README.md
+++ b/website/assets/content/artifacts-wg/README.md
@@ -1,0 +1,1 @@
+../../../../artifacts-wg/README.md

--- a/website/assets/content/artifacts-wg/charter.md
+++ b/website/assets/content/artifacts-wg/charter.md
@@ -1,0 +1,1 @@
+../../../../artifacts-wg/charter/charter.md

--- a/website/content/about/_index.md
+++ b/website/content/about/_index.md
@@ -15,4 +15,5 @@ The TAG establishes working groups (WGs) to accomplish specific projects and ini
 | [GitOps](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg) | [gitops-wg/CHAIRS.md](./gitops-wg/CHAIRS.md) | [gitops-wg/README.md#meetings](./gitops-wg/README.md#meetings) |
 | [Air Gapped](https://github.com/cncf/tag-app-delivery/tree/main/air-gapped-wg)         |   | Inactive |
 | [Operator](https://github.com/cncf/tag-app-delivery/tree/main/operator-wg) | | Inactive |
+|[Artifacts](https://github.com/cncf-tags/wg-artifacts#readme) | [Chairs](https://github.com/cncf-tags/wg-artifacts#chairs) | [Meetings](https://github.com/cncf-tags/wg-artifacts#communications) |
 

--- a/website/content/wgs/artifacts/_index.md
+++ b/website/content/wgs/artifacts/_index.md
@@ -1,0 +1,5 @@
+---
+title: Artifacts Working Group
+list_pages: false
+---
+{{< include path="assets/content/artifacts-wg/README.md" >}}

--- a/website/content/wgs/artifacts/charter/_index.md
+++ b/website/content/wgs/artifacts/charter/_index.md
@@ -1,0 +1,5 @@
+---
+title: Artifacts-WG Charter
+url: 'wgs/artifacts/charter/charter.md/'
+---
+{{< include path="assets/content/artifacts-wg/charter.md" >}}

--- a/website/layouts/shortcodes/include.html
+++ b/website/layouts/shortcodes/include.html
@@ -1,0 +1,1 @@
+{{ readFile (.Get "path") | markdownify }}


### PR DESCRIPTION
This approach adds artifacts-wg content to the website without duplicating it in the website/content folder. The content is symlinked to the website content from its original location in the repo and then read into the website's content with custom shortcode. 

I'm happy to consider alternatives if needed. Thank you. 