### PR TITLE
Extract glossary from Platforms White Paper to top level concern

### DIFF
--- a/platforms-wg/glossary/_index.md
+++ b/platforms-wg/glossary/_index.md
@@ -1,10 +1,6 @@
 ---
 title: Glossary
-list_pages: true
-menu:
-  main:
-    weight: 30
-description: "A collection of terms and used within the TAG published papers."
+description: "A collection of terms used in the Platform Working Group published papers."
 ---
 
 See also <https://glossary.cncf.io/>.

--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -497,52 +497,6 @@ relating it to existing CNCF or CDF projects.
   </tr>
 </table>
 
-## Glossary
-
-See also <https://glossary.cncf.io/>.
-
-A **platform** aggregates capabilities to serve developers and operators in
-development and delivery of products, services and apps. In reference to the
-scenarios it aims to support, a platform may be named a "Developer Platform", a
-"Delivery Platform", an "App Platform" or even a "Cloud Platform." The
-connotations of the older term "Platform-as-a-Service", or PaaS, are also
-influential.
-
-**Platforms** enable developers and operators to deliver applications and
-services faster by providing and managing common capabilities. Platforms bridge
-between platform users and platform capability providers, and are built and
-maintained by platform teams.
-
-**Platform capability providers** develop and maintain the capabilities offered
-by the platform. Providers can be both external organizations or internal teams,
-and capabilities can be infrastructure, runtime, or other supporting services.
-
-**Platform engineers** are responsible for developing and 
-maintaining interfaces and tools to enable provisioning and integration of platform 
-capabilities in applications, according to the requirements and instructions provided 
-by platform product managers. Platform developers are usually grouped in platform teams.
-
-**Platform product managers** are responsible for understanding the experience of
-platform users, building a roadmap that addresses platform product gaps, requirements, 
-and opportunities, and managing platform teams in their daily work.
-
-**Platform teams** are responsible for developing and maintaining the interfaces to 
-and experiences with platform capabilities - like Web portals, custom APIs, and 
-golden path templates.  
-Platform teams are managed by platform product managers and involve
-platform developers. As the platform evolves and become more advanced, other roles 
-can become part of a platform team, including, but not limited to, operators, 
-QA analysts, UI/UX designers, technical writers, developer advocates.
-
-**Platform users** include but aren't limited to app developers and operators, data
-scientists, COTS software operators, and information workers - whoever runs
-software on the platform or uses platform provided capabilities.
-
-**Thinnest viable platform (TVP)** is a concept originally defined in the book *Team Topologies*
-by Matthew Skelton and Manuel Pais. The definition says: "A TVP is a careful balance between 
-keeping the platform small and ensuring that the platform is helping to accelerate and simplify 
-software delivery for teams building on the platform."
-
 <!-- ## Footnotes -->
 
 [1]: https://www.atlassian.com/devops/frameworks/team-topologies

--- a/website/content/glossary/_index.md
+++ b/website/content/glossary/_index.md
@@ -1,0 +1,52 @@
+---
+title: Glossary
+list_pages: true
+menu:
+  main:
+    weight: 30
+description: "A collection of terms and used within the TAG published papers."
+---
+
+See also <https://glossary.cncf.io/>.
+
+A **platform** aggregates capabilities to serve developers and operators in
+development and delivery of products, services and apps. In reference to the
+scenarios it aims to support, a platform may be named a "Developer Platform", a
+"Delivery Platform", an "App Platform" or even a "Cloud Platform." The
+connotations of the older term "Platform-as-a-Service", or PaaS, are also
+influential.
+
+**Platforms** enable developers and operators to deliver applications and
+services faster by providing and managing common capabilities. Platforms bridge
+between platform users and platform capability providers, and are built and
+maintained by platform teams.
+
+**Platform capability providers** develop and maintain the capabilities offered
+by the platform. Providers can be both external organizations or internal teams,
+and capabilities can be infrastructure, runtime, or other supporting services.
+
+**Platform engineers** are responsible for developing and 
+maintaining interfaces and tools to enable provisioning and integration of platform 
+capabilities in applications, according to the requirements and instructions provided 
+by platform product managers. Platform developers are usually grouped in platform teams.
+
+**Platform product managers** are responsible for understanding the experience of
+platform users, building a roadmap that addresses platform product gaps, requirements, 
+and opportunities, and managing platform teams in their daily work.
+
+**Platform teams** are responsible for developing and maintaining the interfaces to 
+and experiences with platform capabilities - like Web portals, custom APIs, and 
+golden path templates.  
+Platform teams are managed by platform product managers and involve
+platform developers. As the platform evolves and become more advanced, other roles 
+can become part of a platform team, including, but not limited to, operators, 
+QA analysts, UI/UX designers, technical writers, developer advocates.
+
+**Platform users** include but aren't limited to app developers and operators, data
+scientists, COTS software operators, and information workers - whoever runs
+software on the platform or uses platform provided capabilities.
+
+**Thinnest viable platform (TVP)** is a concept originally defined in the book *Team Topologies*
+by Matthew Skelton and Manuel Pais. The definition says: "A TVP is a careful balance between 
+keeping the platform small and ensuring that the platform is helping to accelerate and simplify 
+software delivery for teams building on the platform."

--- a/website/content/wgs/platforms/glossary
+++ b/website/content/wgs/platforms/glossary
@@ -1,0 +1,1 @@
+../../../../platforms-wg/glossary


### PR DESCRIPTION
In writing the platforms white paper it was realised that glossary would help clarify some key terms. These were originally added at the end of the white paper for proximity and ease.

During the review of the upcoming platform engineering maturity model it was realised that the entries in this glossary would be useful to the maturity model readers as well.

This PR extracts the glossary into its own top level content. It intentionally does not introduce any new terms or improve any existing terms as that work should be evaluated in independent PRs.

The only "decisions" made in this PR are:
1. The glossary deserves to be its own stand alone page
2. The glossary should be a ~TAG level concern (despite it currently only containing WG Platform terms).~ WG level concern (per feedback in this PR).

<img width="1443" alt="image" src="https://github.com/cncf/tag-app-delivery/assets/1557346/d56af0e2-d481-4c75-a425-adec0f51bacf">
