### PR TITLE
See if this forces netlify to always build preview instances

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../*-whitepaper/"
+  ignore = "echo 1"


### PR DESCRIPTION
Since we have various changes in the base dir of this repo affect the website nested in `/website/`, we'd like to tell netlify not to skip builds as it has been doing. I'm following [the instructions here](https://docs.netlify.com/configure-builds/ignore-builds/#custom-ignore-command).