### PR TITLE
update website README for more clarity

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 			// Update VARIANT to pick hugo variant.
 			// Example variants: hugo, hugo_extended
 			// Rebuild the container if it already exists to update.
-			"VARIANT": "hugo",
+			"VARIANT": "hugo_extended",
 			// Update VERSION to pick a specific hugo version.
 			// Example versions: latest, 0.73.0, 0,71.1
 			// Rebuild the container if it already exists to update.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
+# NOTE: The error in GitHub is for users that have not yet accepted invites to this repository; it is expected.
+
 # CODEOWNERS file indicates code owners for certain files
 #
 # Code owners will automatically be added as a reviewer for PRs that touch
@@ -11,10 +13,10 @@
 *   @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings @kgamanji @justincormack @angellk
 
 # Platforms WG
-/platforms-wg/ @abangser @roberthstrand @joshgav
+/platforms-*/ @abangser @roberthstrand @joshgav
 
 # GitOps WG
-/gitops-wg/ @todaywasawesome @chris-short @scottrigby
+/gitops-*/ @todaywasawesome @chris-short @scottrigby
 
 # Artifacts WG
-/artifacts-wg/ @afflom @rchincha
+/artifacts-*/ @afflom @rchincha

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../*-whitepaper/"
+  ignore = "echo 1"

--- a/website/README.md
+++ b/website/README.md
@@ -1,86 +1,92 @@
 # TAG App Delivery Website
 
-This directory contains a [Hugo](https://gohugo.io) web site published via [Netlify](https://www.netlify.com/) to <https://tag-app-delivery.cncf.io/>.
+This directory contains a [Hugo](https://gohugo.io) web site published via
+[Netlify](https://www.netlify.com/) to <https://tag-app-delivery.cncf.io/>.
 
-When the `main` branch of this repo is updated a fresh build and deploy of the website is executed. Recent Netlify builds and deployments are listed at <https://app.netlify.com/sites/tag-app-delivery>.
+When the `main` branch of this repo is updated a fresh build and deploy of the
+website is executed. Recent Netlify builds and deployments are listed at
+<https://app.netlify.com/sites/tag-app-delivery>.
 
-## Setting up a dev instance
+A preview site is generated for each PR too, with a link and other info on the
+PR build added as a comment to the related issue.
 
-There a two ways to run the webserver for developing the site.
+## Contributing
 
-### Run in Dev Container
-With a development container (called workspace), the entire toolchain can be bundled up and run in any environment that can run containers.
+We feature 3 types of content on the site:
 
-Requirements:
-- [DevPod](https://devpod.sh/docs/getting-started/install)
-- An environment with a [DevPod provider](https://devpod.sh/docs/managing-providers/what-are-providers), e.g. [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+1. **Projects looking for contributions**: These are strictly scoped in both time and content. People can contribute without the need for committing long-term.
+1. **Blogposts**: Updates about the TAG.
+1. **Working Groups**: Long-running interest groups, the scope of which might change. A working group can create multiple projects.
 
-DevPod can be run with a GUI or via CLI.
-
-#### GUI
-
-To start a workspace through the GUI click the below button.
-Then choose the desired provider and IDE.
-
-[![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open)
-
-#### CLI
-To startup a devcontainer through the CLI, follow below steps
-```
-# Add a provider for your environment, e.g. docker (this only needs to be done once)
-devpod provider add docker
-
-# Create workspace from local path
-git clone git@github.com:cncf/tag-app-delivery.git
-cd tag-app-delivery
-devpod up .
-
-# OR Create workspace from remote git repository
-devpod up github.com/cncf/tag-app-delivery
-
-# Start the workspace
-devpod up tag-app-delivery --ide openvscode
-```
-
-Once the workspace is up, DevPod will start your IDE. Open up a terminal to execute the server startup script
-
-```
-/bin/bash .devcontainer/start-server.sh
-```
-Navigate to http://localhost:1313 with your browser to view the site.
-
-### Run directly on machine
-
-To set up a local dev environment make sure you have [Hugo Extended](https://gohugo.io/installation/linux/#editions) and [npm](https://www.npmjs.com/) installed, then run the server startup script:
-
-```
-/bin/bash .devcontainer/start-server.sh
-```
-the output will tell you which port the webserver is serving.
-
-## Add content to website
-Generally speaking, there are three types of content we feature on the website:
-1. **Projects looking for contributions**  
-These are strictly scoped in both time and content. People can contribute without the need for committing long-term.
-1. **Blogposts**  
-Updates about the TAG.
-1. **Working Groups**  
-Longrunning interest groups, the scope of which might change. A working group can create multiple projects.
+Here's how to create templates for each type of content.
 
 ### Create new call for contribution
+
 ```
 cd website
 hugo new content contribute/<project title>.md
 ```
 
 ### Create new blogpost
+
 ```
 cd website
 AUTHOR=ll hugo new content blog/<post title>.md
 ```
 
 ### Create new working group
+
 ```
 cd website
 hugo new wgs/<working group name>
 ```
+
+## Testing locally
+
+### Run in local OS
+
+To run the site from your local OS:
+
+1. Install [Hugo Extended](https://gohugo.io/installation/linux/#editions) and [npm](https://www.npmjs.com/)
+2. Run `git clone git@github.com:cncf/tag-app-delivery.git && cd tag-app-delivery`
+3. Initialize submodules with `git submodule update --init --recursive`
+4. Change into the website directory: `cd website`
+5. Install dependencies with `npm install`
+6. Run the site using `hugo server -D`
+7. Output from the previous command includes the address to browse to preview the site, by default <http://localhost:1313/>.
+
+Alternatively, once you've cloned this repo you can directly invoke the included
+startup script: `./.devcontainer/start-server.sh`
+
+### Run in a special container
+
+You can create a special "development container", also known as a "workspace",
+that includes all dependencies required to build and run the site. This reduces
+potential differences between local developer environments.
+
+To run the site from a development container:
+
+1. Install [DevPod](https://devpod.sh/docs/getting-started/install)
+1. Install a [DevPod provider](https://devpod.sh/docs/managing-providers/what-are-providers)
+   such as [docker](https://www.docker.com/), using `devpod provider add docker`.
+
+### GUI
+
+Open the environment directly:
+
+[![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open#https://github.com/cncf/tag-app-delivery)
+
+### CLI
+
+Start the environment via CLI:
+
+1. Run `git clone git@github.com:cncf/tag-app-delivery.git && cd tag-app-delivery`
+1. Start the workspace: `devpod up .`
+1. Open a terminal and execute `.devcontainer/start-server.sh` to start the Hugo server.
+1. Output from the previous command includes the address to browse to preview the site, by default <http://localhost:1313/>.
+
+Alternatively, create a workspace directly from the repo: `devpod up
+github.com/cncf/tag-app-delivery`
+
+Once the workspace has been created on your machine you can open up it any time
+with `devpod up tag-app-delivery --ide openvscode`

--- a/website/README.md
+++ b/website/README.md
@@ -76,20 +76,23 @@ The startup script updates gitmodules for the theme and installs all necessary d
 ```
 5. Output from the previous command includes the address to browse to preview the site, by default <http://localhost:1313/>.
 
-### GUI
 
-Open the environment directly:
+#### GUI
+
+You can open the devcontainer directly in the DevPod Gui byt pressing the below button:
 
 [![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open#https://github.com/cncf/tag-app-delivery)
 
-### CLI
+Then follow above steps 4 and 5 to run the website
 
-Start the environment via CLI:
+
+#### CLI
+
+Or you can start the dev environment via CLI:
 
 1. Run `git clone git@github.com:cncf/tag-app-delivery.git && cd tag-app-delivery`
 1. Start the workspace: `devpod up .`
-1. Open a terminal and execute `.devcontainer/start-server.sh` to start the Hugo server.
-1. Output from the previous command includes the address to browse to preview the site, by default <http://localhost:1313/>.
+1. Follow above steps 4 and 5 to run the website
 
 Alternatively, create a workspace directly from the repo: `devpod up
 github.com/cncf/tag-app-delivery`

--- a/website/README.md
+++ b/website/README.md
@@ -60,7 +60,7 @@ startup script: `./.devcontainer/start-server.sh`
 
 ### Run in a special container
 
-You can create a special "development container", also known as a "workspace",
+You can create a special "development container",
 that includes all dependencies required to build and run the site. This reduces
 potential differences between local developer environments.
 
@@ -69,6 +69,12 @@ To run the site from a development container:
 1. Install [DevPod](https://devpod.sh/docs/getting-started/install)
 1. Install a [DevPod provider](https://devpod.sh/docs/managing-providers/what-are-providers)
    such as [docker](https://www.docker.com/), using `devpod provider add docker`.
+1. Start the devcontainer (See options below)
+1. Open a terminal and execute `.devcontainer/start-server.sh` to start the Hugo server.
+```
+The startup script updates gitmodules for the theme and installs all necessary dependencies to run hugo.
+```
+5. Output from the previous command includes the address to browse to preview the site, by default <http://localhost:1313/>.
 
 ### GUI
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,34 +1,33 @@
 ---
 title: "CNCF TAG App Delivery"
-toc_hide: true
+list_pages: true
 ---
 
 <div class="row mt-5 mb-3">
     <div class="col-lg-6">
-        <div class="lead">
-        TAG App Delivery supports projects and initiatives related to delivering
-        cloud-native applications, including building, packaging, deploying,
-        managing, and operating them.
-        </div>
+        <img src="/images/tag-app-delivery-horizontal-color.svg" alt="Tag App Delivery logo" style="max-width: 300px;">
     </div>
     <div class="col-lg-6">
-        <img src="/images/tag-app-delivery-horizontal-color.svg" alt="Tag App Delivery logo" style="max-width: 300px;">
+        <div class="lead">
+        Projects and initiatives related to delivering cloud-native
+        applications, including building, packaging, deploying, managing, and
+        operating them.
+        </div>
     </div>
 </div>
 
+The TAG gathers feedback from cloud-native application developers, platform
+engineers and end users; shares that feedback with projects in its domain; and
+produces guidance and examples for end users.
 
-The TAG produces guidance for and gathers feedback from cloud app users and
-developers and provides guidance and coordination to CNCF projects in the TAG's
-technical domains.
+The TAG supports projects relatated to its charter
+such as those in the [CNCF Landscape](https://landscape.cncf.io/card-mode) under
+[application definition and image build](https://landscape.cncf.io/card-mode?category=application-definition-image-build&project=hosted),
+[continuous integration and delivery](https://landscape.cncf.io/card-mode?category=continuous-integration-delivery&project=hosted)
+and [container registry](https://landscape.cncf.io/card-mode?category=container-registry&project=hosted).
 
-- [TAG Charter](https://github.com/cncf/toc/blob/main/tags/app-delivery.md)
-- [Community events](https://community.cncf.io/tag-app-delivery/)
-- Slack channel: [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5)
-    - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
-- [Mailing list](https://lists.cncf.io/g/cncf-tag-app-delivery/topics)
-
-<p class="mt-5"><img src="/images/man-using-laptop.jpg" alt="Man working on computer"></p>
-
+Today there are two active working groups under the TAG -
+[WG Platforms](./wgs/platforms/) and [WG Artifacts](./wgs/artifacts/).
 
 ## Meetings
 
@@ -48,5 +47,15 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 - [Josh Gavant](https://github.com/joshgav) (Chair)
 - [Thomas Schuetz](https://github.com/thschue) (Chair)
 - [Alex Jones](https://github.com/alexsjones) (TL)
-- [Lian Li] (https://github.com/lianmakesthings) (TL)
-- [Karena Angell] (https://github.com/angellk) (TL)
+- [Lian Li](https://github.com/lianmakesthings) (TL)
+- [Karena Angell](https://github.com/angellk) (TL)
+
+### Additional Resources
+
+- [TAG Charter](https://github.com/cncf/toc/blob/main/tags/app-delivery.md)
+- Slack channel: [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5)
+    - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
+- [Mailing list](https://lists.cncf.io/g/cncf-tag-app-delivery/topics)
+
+<p class="mt-5"><img src="/images/man-using-laptop.jpg" alt="Man working on computer"></p>
+

--- a/website/content/blog/2023-10-kubecon-chicago.md
+++ b/website/content/blog/2023-10-kubecon-chicago.md
@@ -15,18 +15,18 @@ application delivery faster and more efficient for end users.
  
 To this end the TAG will host
 [a project meeting](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/program/project-engagement/#in-person-project-working-session)
-on Monday morning at the Marriott; and booth F41 in
+on Monday morning at [the Marriott Marquis](https://maps.app.goo.gl/6gczBxScup8Cn6tBA) on Level 4, room name "Probability"; and booth 41 in
 [the project pavilion](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/program/project-engagement/#project-pavilion)
 at the conference center on Tuesday, Wednesday and Thursday. At these venues we'll be hosting talks and discussions about app
 delivery topics; if you'd like to share an open source project,
 a new idea, or just lead an open discussion please let us know by filling out
 [this form](https://forms.gle/ZbNxrK5f72otckvj7).
 
-Here are those links again:
+Here's that info again:
 
-- Project meeting: <https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/program/project-engagement/#in-person-project-working-session>
-- Project pavilion: <https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/program/project-engagement/#project-pavilion>
-- Form for talk proposals: <https://forms.gle/ZbNxrK5f72otckvj7>
+- Project meeting on Monday 11/6 from 8am-12pm at the [Marriot Marquis](https://maps.app.goo.gl/6gczBxScup8Cn6tBA), Level 4, room name Probability
+- Booth and meetup spot at project pavilion booth #41 on the show floor each afternoon and evening
+- Form for presentation and discussion proposals: <https://forms.gle/ZbNxrK5f72otckvj7>
 
 The TAG will also host
 [a panel discussion](https://kccncna2023.sched.com/event/eb75a050355eccf96c4f1d77a831f7d4)
@@ -38,20 +38,22 @@ delivery topics and learn more about the TAG.
 
 ## Pre-day meetup - Monday morning
 
-The schedule for the project meeting on Monday morning will be as follows:
+The schedule for the project meeting on Monday morning will be as follows. The
+meeting will be live streamed and recorded too.
 
 Time   | Topic
 -------|--------
 Nov 6 @ 08:00  | TAG General Review | [TAG Leads](https://tag-app-delivery.cncf.io/#leads)
-Nov 6 @ 09:15  | Talks on projects, concepts and working groups
-Nov 6 @ 10:45  | Talks on projects, concepts and working groups
+Nov 6 @ 09:00  | Sandbox submission review for [Radius](https://radapp.io/)
+Nov 6 @ 10:00  | Talks on projects, concepts and working groups
+Nov 6 @ 11:00  | Talks on projects, concepts and working groups
 
 ## Booth meetups - Tuesday, Wednesday, Thursday
 
 The schedule for talks at the booth follows:
 
-Date/Time       | Topic | Presenter
-----------------|-------|-----------
+Date/Time       | Topic
+----------------|-------
 Nov 7 @ 17:00 | Talks and discussions
 Nov 8 @ 15:00 | Talks and discussions
 Nov 9 @ 13:00 | Talks and discussions

--- a/website/content/blog/_index.md
+++ b/website/content/blog/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Blog
-toc_hide: true
 menu:
   main:
     weight: 40

--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -16,12 +16,9 @@
 					CNCF Sites</a>
 			</div>
 			<ul class="social-links">
-				<li><a class="text-white" title="Cloud Native Computing Foundation on Twitter"
-						href="https://twitter.com/cloudnativefdn"><svg xmlns="http://www.w3.org/2000/svg"
-							viewbox="-0.61 -0.55 31.72 25.84">
-							<path fill="currentColor"
-								d="M30.579 3.018c-1.145.503-2.36.833-3.603.98A6.252 6.252 0 0 0 29.734.556a12.628 12.628 0 0 1-3.982 1.51A6.297 6.297 0 0 0 22.193.187a6.327 6.327 0 0 0-3.977.655A6.249 6.249 0 0 0 15.46 3.76a6.178 6.178 0 0 0-.398 3.978 17.93 17.93 0 0 1-7.165-1.887 17.784 17.784 0 0 1-5.769-4.614 6.182 6.182 0 0 0-.687 4.533A6.228 6.228 0 0 0 4.07 9.54a6.288 6.288 0 0 1-2.842-.777v.078c0 1.436.502 2.829 1.419 3.94a6.286 6.286 0 0 0 3.614 2.16 6.34 6.34 0 0 1-2.833.107A6.23 6.23 0 0 0 5.66 18.14a6.315 6.315 0 0 0 3.628 1.229 12.657 12.657 0 0 1-7.791 2.663c-.5 0-1-.03-1.497-.087a17.868 17.868 0 0 0 9.617 2.794c11.54 0 17.849-9.479 17.849-17.697 0-.27-.006-.538-.018-.805a12.692 12.692 0 0 0 3.13-3.22z" />
-						</svg> </a></li>
+				<li><a class="text-white" title="Cloud Native Computing Foundation on X"
+					href="https://x.com/cloudnativefdn"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" aria-label="X"><path fill="currentColor" d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8 116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66"/></svg>
+				</a></li>
 				<li><a class="text-white" title="Cloud Native Computing Foundation on Github"
 						href="https://github.com/cncf"><svg xmlns="http://www.w3.org/2000/svg"
 							viewbox="-0.1 0.21 24.7 24.14">

--- a/website/layouts/partials/sidebar-tree.html
+++ b/website/layouts/partials/sidebar-tree.html
@@ -41,9 +41,8 @@
     {{ $ulShow := cond (isset .Site.Params.ui "ul_show") .Site.Params.ui.ul_show 1 -}}
     {{ $sidebarMenuTruncate := cond (isset .Site.Params.ui "sidebar_menu_truncate") .Site.Params.ui.sidebar_menu_truncate 50 -}}
     <ul class="td-sidebar-nav__section pr-md-3 ul-{{ $ulNr }}">
-      {{ if or ( in $navRoot "whitepapers" ) ( in $navRoot "about" ) ( in $navRoot "wgs" ) ( in $navRoot "contribute" ) }}
+      
         {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
-      {{ end }}
     </ul>
   </nav>
 </div>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "tech-doc-hugo",
-  "version": "0.0.1",
+  "name": "tag-app-delivery-website",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tech-doc-hugo",
-      "version": "0.0.1",
-      "license": "ISC",
+      "name": "tag-app-delivery-website",
+      "version": "1.0.0",
+      "license": "MIT",
       "devDependencies": {
-        "autoprefixer": "^10.4.0",
-        "postcss": "^8.3.7",
-        "postcss-cli": "^9.0.2"
+        "autoprefixer": "^10.4",
+        "postcss": "^8.4",
+        "postcss-cli": "^10.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -86,22 +86,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/array-union": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-      "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
       "dev": true,
       "funding": [
         {
@@ -111,12 +99,16 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
-        "fraction.js": "^4.2.0",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -153,9 +145,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
       "funding": [
         {
@@ -165,13 +157,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -181,9 +177,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001441",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+      "version": "1.0.30001551",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz",
+      "integrity": "sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==",
       "dev": true,
       "funding": [
         {
@@ -193,6 +189,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "version": "1.4.563",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.563.tgz",
+      "integrity": "sha512-dg5gj5qOgfZNkPNeyKBZQAQitIQ/xwfIDmEQJHCbXaD9ebTZxwJXUsDYcBlAvZGZLi+/354l35J1wkmP6CqYaw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -335,22 +335,22 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
       "dev": true,
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -358,13 +358,13 @@
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -409,15 +409,14 @@
       }
     },
     "node_modules/globby": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
-      "integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
       "dev": true,
       "dependencies": {
-        "array-union": "^3.0.1",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.7",
-        "ignore": "^5.1.9",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
         "merge2": "^1.4.1",
         "slash": "^4.0.0"
       },
@@ -428,10 +427,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/ignore": {
@@ -507,9 +518,9 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -538,10 +549,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -550,9 +567,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -610,9 +627,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -622,10 +639,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -634,45 +655,45 @@
       }
     },
     "node_modules/postcss-cli": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-9.1.0.tgz",
-      "integrity": "sha512-zvDN2ADbWfza42sAnj+O2uUWyL0eRL1V+6giM2vi4SqTR3gTYy8XzcpfwccayF2szcUif0HMmXiEaDv9iEhcpw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-10.1.0.tgz",
+      "integrity": "sha512-Zu7PLORkE9YwNdvOeOVKPmWghprOtjFQU3srMUGbdz3pHJiFh7yZ4geiZFMkjMfB0mtTFR3h8RemR62rPkbOPA==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.0",
         "dependency-graph": "^0.11.0",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^11.0.0",
         "get-stdin": "^9.0.0",
-        "globby": "^12.0.0",
+        "globby": "^13.0.0",
         "picocolors": "^1.0.0",
-        "postcss-load-config": "^3.0.0",
+        "postcss-load-config": "^4.0.0",
         "postcss-reporter": "^7.0.0",
         "pretty-hrtime": "^1.0.3",
         "read-cache": "^1.0.0",
-        "slash": "^4.0.0",
+        "slash": "^5.0.0",
         "yargs": "^17.0.0"
       },
       "bin": {
         "postcss": "index.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
       "dev": true,
       "dependencies": {
         "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
+        "yaml": "^2.1.1"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       },
       "funding": {
         "type": "opencollective",
@@ -810,12 +831,12 @@
       }
     },
     "node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -884,9 +905,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {
@@ -896,6 +917,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -903,7 +928,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -936,18 +961,18 @@
       }
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
+      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
       "dev": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "tech-doc-hugo",
-  "version": "0.0.1",
-  "description": "Hugo theme for technical documentation.",
+  "name": "tag-app-delivery-website",
+  "version": "1.0.0",
+  "description": "TAG website based on Hugo",
   "main": "none.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/google/docsy-example.git"
+    "url": "git+https://github.com/cncf/tag-app-delivery"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "CNCF TAG App Delivery",
+  "license": "MIT",
   "bugs": {
-    "url": "https://github.com/google/docsy-example/issues"
+    "url": "https://github.com/cncf/tag-app-delivery/issues"
   },
-  "homepage": "https://github.com/google/docsy-example#readme",
+  "homepage": "https://github.com/cncf/tag-app-delivery",
   "devDependencies": {
-    "autoprefixer": "^10.4.0",
-    "postcss": "^8.3.7",
-    "postcss-cli": "^9.0.2"
+    "autoprefixer": "^10.4",
+    "postcss": "^8.4",
+    "postcss-cli": "^10.1"
   }
 }


### PR DESCRIPTION
I'm working on the site and wanted to clarify the instructions in the README. This PR:

- Moves general instructions about content types and how to create them to the beginning of the doc
- Cleans up the instructions on how to run on a local machine and bumps them before the DevPod instructions
- Fixes the `https://devpod.sh/open` link to include the parameter for the target site
- Fixes up some of the prose around DevPod option

Here's a direct link to the rendering of the new page for review: <https://github.com/cncf/tag-app-delivery/blob/e061258262b10682ef01ed2798e9ef4c3342f5d4/website/README.md>

Also will note that for me following the DevPod instructions yields a workspace but I can't actually access the files and scripts in that workspace. But I'm deferring troubleshooting that.

cc @lianmakesthings @abangser 