### PR TITLE
Maturity model v1

### DIFF
--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -80,7 +80,7 @@ This yields a potential process for platform development and maturity similar to
 
 Similar to the [CNCF Cloud Native Maturity Model](https://maturitymodel.cncf.io/), this model highlights that successful business outcomes can only be achieved through balancing people, process, and policy alongside technology. Notably, this model introduces aspects which are often not fully in the remit of a single internal team, but rather require cooperation across the engineering department and quite often the wider organization.
 
-### But we don’t fit
+### But it doesn't seem to fit
 
 That’s perfectly fine! All organizations and groups have dynamics and parameters that are specific to them.
 

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -55,6 +55,40 @@ Finally, this model encourages organizations to mature their platform engineerin
 
 In general, keep in mind that mapping your organization into a model captures current state _to enable_ progressive iteration and improvement. [Martin Fowler](https://martinfowler.com/bliki/MaturityModel.html) says it well: "The true outcome of a maturity model assessment isn't what level you are at but the list of things you need to work on to improve. Your current level is merely a piece of intermediate work in order to determine that list of skills to acquire next." In that vein, seek to find yourself in the model then identify opportunities in adjacent levels.
 
+## Context behind this work
+
+It's valuable to understand the context a document has been written in. The following sections lay out some context behind the model as well as some expectations for you, the reader.
+
+### Intended audiences
+
+Each reader brings a unique context and will take unique learnings from this model. Following are some personas we have in mind, along with their possible motivations for engaging with this model:
+
+* **CTOs, VPs, and directors of technology**: Leaders looking to map a path to digital transformation and greater developer productivity
+* **Engineering managers**: Groups and individuals seeking to empower engineers to provide value with less overhead and higher efficiency
+* **Enterprise architects**: Individuals navigating the modern technology landscape who seek a value- and solution-oriented perspective on technology problems
+* **Platform engineers and platform product managers**: Teams and people seeking to build the best possible experience for platform builders and platform users
+* **Product vendors and project maintainers**: Organizations and engineers wishing to design tools and deliver messages to enable users to succeed with platforms and capabilities
+* **Application and product developers**: Platform users seeking to understand in more detail what they might expect of an internal platform
+
+### Understanding the levels
+
+This model is not meant to classify an organization or platform team as wholly “Level 1” or “Level 4.” Each aspect should be considered independently of the others; the characteristics of each level represent a continuum within that aspect but are not necessarily coupled to other aspects at the same level. Even more so, many organizations will see characteristics of more than one level being applicable across their teams and work. This is because no level is inherently good or bad, only contextual to the team’s goals.
+
+The labels for each level are intended to reflect the impact of platform engineering at your organization. As you recognize your organization at a given level you will gain insight into opportunities which follow at the next ones. Lower-numbered levels comprise more tactical solutions while higher-numbered ones are more strategic.
+
+This yields a potential process for platform development and maturity similar to other digital product development: first recognize a problem and need for a new solution, next develop minimally-viable products as hypothesized solutions, third iterate to better solve the problem and ensure fit for your customers and finally scale and optimize the product to solve the problem for many teams and users.
+
+Similar to the [CNCF Cloud Native Maturity Model](https://maturitymodel.cncf.io/), this model highlights that successful business outcomes can only be achieved through balancing people, process, and policy alongside technology. Notably, this model introduces aspects which are often not fully in the remit of a single internal team, but rather require cooperation across the engineering department and quite often the wider organization.
+
+### But we don’t fit
+
+That’s perfectly fine! All organizations and groups have dynamics and parameters that are specific to them.
+
+Keep in mind that the goal of this paper isn’t to prescribe a rigid formula, but rather a framework that you can apply to your circumstances. Every single word may not be relevant to you, but we hope the content will inspire you to introspect on your own platform journey, taking what makes sense and leaving the rest.
+
+The objective of this model is to provide a tool to help guide platform engineering practitioners, stakeholders, and other interested parties on their journeys. Platform design and implementation is not an exact science, but rather depends on the needs of an individual project, an organization and a particular time and place.
+
+
 ## Model table
 
 | <div style="width:120px">Aspect </div> |                                                                                            | Provisional            | Operational           | Scalable               | Optimizing                   |
@@ -69,42 +103,6 @@ In general, keep in mind that mapping your organization into a model captures cu
 
 <div style="min-width:620px">
 {{< tabs tabTotal="6">}}
-{{< tab tabName="Context" >}}
-
-<h4 style="color:gray;padding-bottom:10px;padding-top:20px"><i>Context of this work</i></h4>
-
-It's valuable to understand the context a document has been written in. The following sections lay out some context behind the model as well as some expectations for you, the reader.
-
-## How this model was constructed
-
-This model is not meant to classify an organization or platform team as wholly “Level 1” or “Level 4.” Each aspect should be considered independently of the others; the characteristics of each level represent a continuum within that aspect but are not necessarily coupled to other aspects at the same level. Even more so, many organizations will see characteristics of more than one level being applicable across their teams and work. This is because no level is inherently good or bad, only contextual to the team’s goals.
-
-The labels for each level are intended to reflect the impact of platform engineering at your organization. As you recognize your organization at a given level you will gain insight into opportunities which follow at the next ones. Lower-numbered levels comprise more tactical solutions while higher-numbered ones are more strategic.
-
-This yields a potential process for platform development and maturity similar to other digital product development: first recognize a problem and need for a new solution, next develop minimally-viable products as hypothesized solutions, third iterate to better solve the problem and ensure fit for your customers and finally scale and optimize the product to solve the problem for many teams and users.
-
-Similar to the [CNCF Cloud Native Maturity Model](https://maturitymodel.cncf.io/), this model highlights that successful business outcomes can only be achieved through balancing people, process, and policy alongside technology. Notably, this model introduces aspects which are often not fully in the remit of a single internal team, but rather require cooperation across the engineering department and quite often the wider organization.
-
-## But we don’t fit!
-
-That’s perfectly fine! All organizations and groups have dynamics and parameters that are specific to them.
-
-Keep in mind that the goal of this paper isn’t to prescribe a rigid formula, but rather a framework that you can apply to your circumstances. Every single word may not be relevant to you, but we hope the content will inspire you to introspect on your own platform journey, taking what makes sense and leaving the rest.
-
-The objective of this model is to provide a tool to help guide platform engineering practitioners, stakeholders, and other interested parties on their journeys. Platform design and implementation is not an exact science, but rather depends on the needs of an individual project, an organization and a particular time and place.
-
-## Intended audiences
-
-Each reader brings a unique context and will take unique learnings from this model. Following are some personas we have in mind, along with their possible motivations for engaging with this model:
-
-* **CTOs, VPs, and directors of technology**: Leaders looking to map a path to digital transformation and greater developer productivity
-* **Engineering managers**: Groups and individuals seeking to empower engineers to provide value with less overhead and higher efficiency
-* **Enterprise architects**: Individuals navigating the modern technology landscape who seek a value- and solution-oriented perspective on technology problems
-* **Platform engineers and platform product managers**: Teams and people seeking to build the best possible experience for platform builders and platform users
-* **Product vendors and project maintainers**: Organizations and engineers wishing to design tools and deliver messages to enable users to succeed with platforms and capabilities
-* **Application and product developers**: Platform users seeking to understand in more detail what they might expect of an internal platform
-
-{{< /tab >}}
 {{< tab tabName="Investment" >}}
 
 <h4 style="color:gray;padding-bottom:10px;padding-top:20px"><i>How are staff and funds allocated to platform capabilities?</i></h4>

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -10,6 +10,25 @@ type: whitepapers
 url: /whitepapers/platform-eng-maturity-model
 ---
 
+
+<script>
+window.onhashchange = function() {
+  // get the fragment without the `#`
+  const fragment = window.location.hash.substring(1)
+  const found = Array.from(document.querySelectorAll('.nav-item'))
+    .filter(el => el.textContent === fragment)
+  if (!found) {
+    return
+  }
+
+  if (found.length > 1) {
+    console.warn(`Found multiple ` + "`.nav-item`s" + ` with the text ${parts[1]}, only opening the first one`)
+  }
+
+  found[0].click();
+}
+</script>
+
 ## Introduction
 
 CNCF's initial [Platforms Definition white paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/) describes what internal platforms for cloud computing are and the values they promise to deliver to enterprises. But to achieve those values an organization must reflect and deliberately pursue outcomes and practices that are impactful for them, keeping in mind that every organisation relies on an internal platform crafted for its own organization - even if that platform is just documentation on how to use third party services. This maturity model provides a framework for that reflection and for identifying opportunities for improvement in any organization.
@@ -40,11 +59,11 @@ In general, keep in mind that mapping your organization into a model captures cu
 
 | <div style="width:120px">Aspect </div> |                                                                                            | Provisional            | Operational           | Scalable               | Optimizing                   |
 |:---------------------------------------|:-------------------------------------------------------------------------------------------|:-----------------------|:----------------------|:-----------------------|:-----------------------------|
-| [Investment](#tab-text-Investment)     | _How are staff and funds allocated to platform capabilities?_                              | Voluntary or temporary | Dedicated team        | As product             | Enabled ecosystem            |
-| [Adoption](#tab-text-Adoption)         | _Why and how do users discover and use internal platforms and platform capabilities?_      | Erratic                | Extrinsic push        | Intrinsic pull         | Participatory                |
-| [Interfaces](#tab-text-Interfaces)     | _How do users interact with and consume platform capabilities?_                            | Custom processes       | Standard tooling      | Self-service solutions | Integrated services          |
-| [Operations](#tab-text-Operations)     | _How are platforms and their capabilities planned, prioritized, developed and maintained?_ | By request             | Centrally tracked     | Centrally enabled      | Managed services             |
-| [Measurement](#tab-text-Measurement)   | _What is the process for gathering and incorporating feedback and learning?_               | Ad hoc                 | Consistent collection | Insights               | Quantitative and qualitative |
+| [Investment](#Investment)     | _How are staff and funds allocated to platform capabilities?_                              | Voluntary or temporary | Dedicated team        | As product             | Enabled ecosystem            |
+| [Adoption](#Adoption)         | _Why and how do users discover and use internal platforms and platform capabilities?_      | Erratic                | Extrinsic push        | Intrinsic pull         | Participatory                |
+| [Interfaces](#Interfaces)     | _How do users interact with and consume platform capabilities?_                            | Custom processes       | Standard tooling      | Self-service solutions | Integrated services          |
+| [Operations](#Operations)     | _How are platforms and their capabilities planned, prioritized, developed and maintained?_ | By request             | Centrally tracked     | Centrally enabled      | Managed services             |
+| [Measurement](#Measurement)   | _What is the process for gathering and incorporating feedback and learning?_               | Ad hoc                 | Consistent collection | Insights               | Quantitative and qualitative |
 
 ## Model Detail
 

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -494,6 +494,9 @@ Not only are standard frameworks leveraged, but there is an understanding that m
 {{< /tabs >}}
 </div>
 
+</br>
+
+---
 ## Conclusion
 
 Platforms and their maintainers provide a foundation for agile digital product development. They provide a consistent collection of capabilities that enable efficient software development and delivery. This maturity model provides a map for your platform engineering journey.

--- a/website/layouts/shortcodes/tabs.html
+++ b/website/layouts/shortcodes/tabs.html
@@ -1,5 +1,5 @@
 <nav>
-    <div class="nav nav-tabs" id="nav-tab" role="tablist" style="width:710px">
+    <div class="nav nav-tabs" id="nav-tab" role="tablist">
 
         {{ $tabTotal := .Get "tabTotal" }}
         {{ $tabRightAlign := .Get "tabRightAlign" }}


### PR DESCRIPTION
This change has 4 commits, each for a different value:
1. Fix the links from the table to the tabs
2. Move the context up from in the tabs to the body of the paper
3. Fix the horizontal bar delineating between the table details and the conclusion
4. Nit wording change on one sub title

These changes can be evaluated for merge separately and if needed I can break them apart. The real core of this is around where the context for the model should live. This change is being proposed based on @krumware's ask [here](https://github.com/cncf/tag-app-delivery/pull/472#issuecomment-1776333603) which was discussed on the WG call on Tuesday Oct 24. It seemed like there was strong support for making the context more central to the doc by moving it back and that this would actually reduce confusion caused by the multiple uses of the tabs.

cc/ @joshgav 