### PR TITLE
update WG directory pattern in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
+# NOTE: The error in GitHub is for users that have not yet accepted invites to this repository; it is expected.
+
 # CODEOWNERS file indicates code owners for certain files
 #
 # Code owners will automatically be added as a reviewer for PRs that touch
@@ -11,10 +13,10 @@
 *   @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings @kgamanji @justincormack @angellk
 
 # Platforms WG
-/platforms-wg/ @abangser @roberthstrand @joshgav
+/platforms-*/ @abangser @roberthstrand @joshgav
 
 # GitOps WG
-/gitops-wg/ @todaywasawesome @chris-short @scottrigby
+/gitops-*/ @todaywasawesome @chris-short @scottrigby
 
 # Artifacts WG
-/artifacts-wg/ @afflom @rchincha
+/artifacts-*/ @afflom @rchincha


### PR DESCRIPTION
Updates CODEOWNERS so that WG's own all of their directories.

Also notes reason for error in GitHub: it's because named users are not members of the repository yet. In the current case their invites had expired so I resent.

fixes #287