### PR TITLE
Fix ignore command for builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "echo 1"
+  ignore = "exit 1"


### PR DESCRIPTION
According to [this thread](https://answers.netlify.com/t/support-guide-how-to-use-the-ignore-command/37517) I should be using the `exit` command here.