### PR TITLE
final update to Kubecon Chicago blog

### DIFF
--- a/website/content/blog/2023-10-kubecon-chicago.md
+++ b/website/content/blog/2023-10-kubecon-chicago.md
@@ -26,7 +26,7 @@ The project meeting will also be [livestreamed to YouTube](https://www.youtube.c
 Here's that info again:
 
 - Project meeting on Monday 11/6 from 8am-12pm at the [Marriot Marquis](https://maps.app.goo.gl/6gczBxScup8Cn6tBA), Level 4, room name Probability and [YouTube](https://www.youtube.com/watch?v=NZCmYRVziGY).
-- Booth and meetup spot at project pavilion booth #41 on the show floor each afternoon and evening
+- Booth and meetup spot at project pavilion booth #P10 on the show floor each afternoon and evening
 - Form for presentation and discussion proposals: <https://forms.gle/ZbNxrK5f72otckvj7>
 
 The TAG will also host

--- a/website/content/blog/2023-10-kubecon-chicago.md
+++ b/website/content/blog/2023-10-kubecon-chicago.md
@@ -46,11 +46,11 @@ Time   | Topic | Presenter
 -------|-------|------
 08:00  | TAG General Review | [TAG Leads](https://tag-app-delivery.cncf.io/#leads)
 09:00  | Sandbox submission review for [Radius](https://radapp.io/) | Jonathan Smith, Microsoft
-09:40  | Workload Specifications: Your Best Friends In Platform Engineering | Atulpriya Sharma, InfraCloud
 10:00  | Learn about and discuss [CNOE](https://cnoe.io/) | Nima Kaviani, AWS
-10:40  | Automating the Deployment of Data Workloads to Kubernetes with ArgoCD, Argo Workflows, and Hera | Matt Menzenski, Payit
-11:00  | Beyond the Bundle: Porter and CNAB | Sarah Christoff, Microsoft
-11:15  | Open discussion | [TAG Leads](https://tag-app-delivery.cncf.io/#leads)
+11:00  | Workload Specifications: Your Best Friends In Platform Engineering | Atulpriya Sharma, InfraCloud
+\-     | Automating the Deployment of Data Workloads to Kubernetes with ArgoCD, Argo Workflows, and Hera | Matt Menzenski, Payit
+\-     | Beyond the Bundle: Porter and CNAB | Sarah Christoff, Microsoft
+\-     | From Apps to Stacks: Delivering Reusable Analytic Stacks on Kubernetes | Robert Hodges, Altinity
 
 ## Booth meetups - Tuesday, Wednesday, Thursday
 
@@ -61,6 +61,8 @@ Date/Time     | Topic
 Nov 7 @ 17:00 | Chat with participants from [Platforms Panel](https://kccncna2023.sched.com/event/eb75a050355eccf96c4f1d77a831f7d4)
 Nov 8 @ 15:00 | Talks and discussions
 \-            | Speed up your API delivery with Microcks | Yacine Kheddache, Microcks
-Nov 9 @ 13:00 | Talks and discussions
+\-            | How to Build a GitOps Internal Developer Platform on Kubernetes | Christina Andonov, AWS
+\-            | KubeConstellations: Platform Engineering Patterns | Ram Iyengar, Cloud Foundry
+\-            | AAA framework & DCD capability map for Platform Engineering | Vishal Biyani, InfraCloud
 
 See you in Chicago!


### PR DESCRIPTION
Update calendar for Wednesday "meetup", update Monday to reflect actual speakers and schedule.