### PR TITLE
Introduce taxonomy for blog pages

### DIFF
--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -20,7 +20,7 @@ The TAG gathers feedback from cloud-native application developers, platform
 engineers and end users; shares that feedback with projects in its domain; and
 produces guidance and examples for end users.
 
-The TAG supports projects relatated to its charter
+The TAG supports projects related to its charter
 such as those in the [CNCF Landscape](https://landscape.cncf.io/card-mode) under
 [application definition and image build](https://landscape.cncf.io/card-mode?category=application-definition-image-build&project=hosted),
 [continuous integration and delivery](https://landscape.cncf.io/card-mode?category=continuous-integration-delivery&project=hosted)
@@ -58,4 +58,3 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 - [Mailing list](https://lists.cncf.io/g/cncf-tag-app-delivery/topics)
 
 <p class="mt-5"><img src="/images/man-using-laptop.jpg" alt="Man working on computer"></p>
-

--- a/website/content/en/blog/2023-10-kubecon-chicago.md
+++ b/website/content/en/blog/2023-10-kubecon-chicago.md
@@ -3,6 +3,10 @@ title:  TAG App Delivery at Kubecon Chicago
 slug:   tag-app-delivery-at-kubecon-chicago
 date:   2023-10-09 12:00:00 +0000
 author: Josh Gavant
+categories:
+- Announcement
+tags:
+- Event
 ---
 
 ![Kubecon Chicago 2023](/images/kubecon-chicago-2023.jpg)

--- a/website/content/en/blog/announce-platforms-paper.md
+++ b/website/content/en/blog/announce-platforms-paper.md
@@ -1,7 +1,11 @@
 ---
 title:  "Announcing a Whitepaper on Platforms for Cloud-native Computing"
 date:   2023-04-10 01:00:00 +0000
-author: Josh Gavant, Abby Bangser 
+author: Josh Gavant, Abby Bangser
+categories:
+- Announcement
+tags:
+- WG Platforms
 ---
 
 <img src="../assets/platforms-pyramid.png" width=400px />

--- a/website/content/en/blog/announcing-the-platform-engineering-maturity-model.md
+++ b/website/content/en/blog/announcing-the-platform-engineering-maturity-model.md
@@ -2,6 +2,10 @@
 title: 'Announcing the Platform Engineering Maturity Model'
 date:   2023-11-01 00:00:00 +0000
 author: Abby Bangser, Josh Gavant
+categories:
+- Announcement
+tags:
+- WG Platforms
 ---
 
 The CNCF Platforms Working Group (WG) is excited to present the first release of a platform engineering maturity model which provides a more concrete application of the extremely well received white paper from this past April.

--- a/website/content/en/blog/clusters-for-all-cloud-tenants.md
+++ b/website/content/en/blog/clusters-for-all-cloud-tenants.md
@@ -1,7 +1,12 @@
 ---
 title:  "Clusters for all cloud tenants"
 date:   2022-06-02 13:04:00 +0200
-author: Josh Gavant 
+author: Josh Gavant
+categories:
+- Article
+tags:
+- WG Multi-tenancy
+- Community Contribution
 ---
 
 A decision which faces many large organizations as they adopt cloud architecture is how to provide isolated spaces within the same environments and clusters for various teams and purposes. For example, marketing and sales applications may need to be isolated from an organization's customer-facing applications; and development teams building any app usually require extra spaces for tests and verification.

--- a/website/content/en/blog/cooperative-delivery-platforms.md
+++ b/website/content/en/blog/cooperative-delivery-platforms.md
@@ -2,6 +2,11 @@
 title:  "Infrastructure for Apps: Platforms for Cooperative Delivery"
 date:   2022-09-22 00:00:00 +0000
 author: Josh Gavant
+categories:
+- Announcement
+tags:
+- WG Platforms
+- Event
 ---
 
 ![infrastructure integration](/images/infrastructure-integration.png)

--- a/website/content/en/blog/kubecon-eu-2023.md
+++ b/website/content/en/blog/kubecon-eu-2023.md
@@ -2,6 +2,10 @@
 title:  TAG App Delivery at Kubecon EU 2023
 date:   2023-04-14 12:00:00 +0000
 author: Josh Gavant
+categories:
+- Announcement
+tags:
+- Event
 ---
 
 ![Kubecon EU 2023](/images/kubecon-eu-2023.jpg)

--- a/website/content/en/blog/kubeconna-project-meeting.md
+++ b/website/content/en/blog/kubeconna-project-meeting.md
@@ -2,6 +2,10 @@
 title:  TAG App Delivery at Kubecon NA 2022
 date:   2022-09-12 12:00:00 +0000
 author: Jennifer Strejevitch and Josh Gavant
+categories:
+- Announcement
+tags:
+- Event
 ---
 
 Join CNCF TAG App Delivery and our working groups at Kubecon in Detroit October 24-28.


### PR DESCRIPTION
Hugo has the built in ability to do categories and tags. Using them can enable things like word clouds, pages that highlight aligned content and more.

Right now this is just the first introduction of categories and tags and is being used only for styling a single blog post. This formatting will help us enable more community posts by being clear when things are TAG/WG created vs community submitted.

This will be formalised in #495 and be retrospectively applied to #515 and available for a few more that I know people are interested in proposing.

The proposed taxonomy is:

* *Categories* should be minimal and applicable across a number of tags. Therefore there are only two:
  * announcements
  * community
* *Tags* can help identify sub topics that are more narrow focuses. Right now there are proposed tags:
  * KubeCon
  * Technology
  * WG Multi-tenancy
  * WG Platforms

## Help wanted

I am no designer, to say the least 😅 This could use a look over on they use of Hugo (maybe @cjyabraham ?) and also general desired design (also maybe Chris, but also anyone else!)