### PR TITLE
Add Keycloak to Example CNCF/CDF Projects

### DIFF
--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -483,7 +483,7 @@ relating it to existing CNCF or CDF projects.
   <tr>
     <td>Identity and secret services</td>
     <td>Ensure workloads have locators and secrets to use resources and capabilities. Enable services to identify themselves to other services</td>
-    <td>Dex, External Secrets, SPIFFE/SPIRE, Teller, cert-manager</td>
+    <td>Keycloak, Dex, External Secrets, SPIFFE/SPIRE, Teller, cert-manager</td>
   </tr>
   <tr>
     <td>Security services</td>


### PR DESCRIPTION
This PR proposes adding Keycloak to Example CNCF/CDF Projects of Identity and secret services Capability in CNCF Platforms White Paper.
Keycloak is a CNCF incubating project and an identity and access management OSS.