### PR TITLE
Style blog tags and create browse-by-tag screen

### DIFF
--- a/website/assets/scss/_styles_project.scss
+++ b/website/assets/scss/_styles_project.scss
@@ -15,6 +15,7 @@
 @import 'header';
 @import 'main';
 @import 'search';
+@import 'tax-search';
 @import 'sidebar-left';
 @import 'cookie-banner';
 @import 'sidebar-toc';

--- a/website/assets/scss/_tax-search.scss
+++ b/website/assets/scss/_tax-search.scss
@@ -1,0 +1,124 @@
+// Hide the sidebar on Taxonomy Search/Browse page.
+.td-taxonomy .td-sidebar-nav {
+    display: none !important;
+}
+
+// Adding padding to bottom of Taxonomy Browse page.
+.td-taxonomy .td-main main {
+    padding-bottom: 6rem;
+}
+
+// Tags container.
+.canonical-tag-container {
+    margin-top: 1.5625rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+    gap: 20px;
+    @media (min-width: 768px) {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-bottom: 3rem;
+    }
+    @media (max-width: 767px) {
+        > span {
+            display: flex;
+            align-items: center;
+            align-content: center;
+            justify-content: center;
+        }
+    }
+}
+
+// Tag item. Default gray.
+.canonical-tag {
+    // button reset
+    border: none;
+    background: none;
+    box-sizing: border-box;
+    // button sizing.
+    min-width: 96px;
+    // style to match _taxonomy/.tax-term
+    display: block;
+    background: #efefef;
+    color: black;
+    border-radius: 50px;
+    padding-top: 7px;
+    padding-bottom: 7px;
+    padding-left: 18px;
+    padding-right: 18px;
+    font-weight: 600;
+    font-size: 10px;
+    line-height: 120%;
+    text-align: center;
+    letter-spacing: 0.02em;
+    // Turn pink when selected is-active.
+    &.is-active {
+        background-color: $link-color;
+        color: white;
+        @media (hover: hover) {
+            &:hover {
+                background-color: $link-color;
+                color: white;
+            }
+        }
+    }
+    @media (hover: hover) {
+        // Hover default state.
+        &:hover {
+            background-color: #d2d2d2;
+        }
+    }
+}
+
+// Reset buttons to look like text.
+.button-reset-to-text {
+    border: none;
+    background: none;
+    box-sizing: border-box;
+    padding: 0;
+    cursor: pointer;
+    display: block;
+    margin-left: initial;
+    margin-right: initial;
+    width: unset;
+    // styling.
+    font-size: 10px;
+    line-height: 120%;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: black;
+    &:active {
+        color: inherit;
+    }
+    &:hover {
+        color: $link-color;
+    }
+}
+
+// Results
+#posts-by-tag {
+    margin-top: 1rem;
+    > div {
+        margin-top: 2.5rem;
+    }
+    h3 {
+        margin-top: 2.5rem;
+        margin-bottom: 1rem;
+        a {
+            color: black;
+            &:hover {
+                color: $link-color;
+            }
+        }
+    }
+}
+
+// Tag results.
+.invisible {
+    visibility: hidden;
+}
+
+.hide {
+    display: none;
+}

--- a/website/assets/scss/_taxonomy.scss
+++ b/website/assets/scss/_taxonomy.scss
@@ -1,35 +1,53 @@
-// Container for Taxonomy items.
 .article-meta {
 	margin-bottom: 3rem;
-}
-
-.tax-term {
-	background-color: $link-color;
-	border-radius: 50px;
-	font-weight: 500;
-	font-size: 10px;
-	line-height: 140%;
-	text-align: center;
-	letter-spacing: 0.02em;
-	color: $white;
-	padding: 5px 12px;
-	margin-right: 8px;
-	&:hover {
-		color: $white;
-		text-decoration: none;
-		background-color: $primary-300;
-	}
 }
 
 .taxonomy-terms {
 	list-style: none;
 	margin: 0;
-	overflow: hidden;
 	padding: 0;
+	overflow: hidden;
 	display: flex;
 	flex-wrap: wrap;
+	gap: 13px;
 }
 
+.taxo-tags {
+	.tax-term {
+		display: block;
+		color: $white;
+		background-color: $link-color;
+		border-radius: 50px;
+		padding-top: 7px;
+		padding-bottom: 7px;
+		padding-left: 15px;
+		padding-right: 15px;
+		font-weight: 600;
+		font-size: 10px;
+		line-height: 120%;
+		text-align: center;
+		letter-spacing: 0.02em;
+		&:hover {
+			color: $white;
+			text-decoration: none;
+			background-color: $primary-300;
+		}
+	}
+}
+
+.taxo-categories {
+	.tax-term {
+		color: #747474;
+		display: inline-block;
+		font-size: 16px;
+		font-weight: 700;
+		letter-spacing: .15em;
+		line-height: 9px;
+		text-transform: uppercase;
+	}
+}
+
+// Used in Tax Terms Cloud
 .tax-terms {
 	list-style: none;
 	margin: 60px 0;
@@ -39,6 +57,7 @@
 	}
 }
 
+// Used in Tax Terms Cloud
 .taxonomy-count {
 	padding-left: 0;
 	margin-left: 0;

--- a/website/config.toml
+++ b/website/config.toml
@@ -16,7 +16,7 @@ theme = ["hugo-dynamic-tabs", "docsy"]
 enableGitInfo = true
 
 # Comment out to enable taxonomies in Docsy
-disableKinds = ["taxonomy", "taxonomyTerm"]
+# disableKinds = ["taxonomy", "taxonomyTerm"]
 
 
 # Highlighting config

--- a/website/i18n/en.toml
+++ b/website/i18n/en.toml
@@ -10,3 +10,21 @@ other = "Create issue"
 # TOC
 [page_contents]
 other = "Page Contents"
+
+# Phrases for tags
+[ui_see_all_tags]
+other = "See all tags"
+[ui_tag]
+other = "Tag"
+[ui_tags]
+other = "Tags"
+[ui_search_by_tags]
+other = "Browse by Tags"
+[ui_tags_intro]
+other = "Use the filters to browse blog posts by tag."
+[ui_or_search_by_tags]
+other = "...or browse by tag"
+[ui_select_all]
+other = "Select All"
+[ui_deselect_all]
+other = "Deselect All"

--- a/website/i18n/ko.toml
+++ b/website/i18n/ko.toml
@@ -8,3 +8,21 @@ other = "issue 생성"
 # TOC
 [page_contents]
 other = "페이지 내용"
+
+# Phrases for tags
+[ui_see_all_tags]
+other = "See all tags"
+[ui_tag]
+other = "Tag"
+[ui_tags]
+other = "Tags"
+[ui_search_by_tags]
+other = "Browse by Tags"
+[ui_tags_intro]
+other = "We've categorized the glossary terms. Use the filters to browse terms by tag."
+[ui_or_search_by_tags]
+other = "...or browse by tag"
+[ui_select_all]
+other = "Select All"
+[ui_deselect_all]
+other = "Deselect All"

--- a/website/i18n/zh.toml
+++ b/website/i18n/zh.toml
@@ -8,3 +8,21 @@ other = "新建 Issue"
 # TOC
 [page_contents]
 other = "本页内容"
+
+# Phrases for tags
+[ui_see_all_tags]
+other = "See all tags"
+[ui_tag]
+other = "Tag"
+[ui_tags]
+other = "Tags"
+[ui_search_by_tags]
+other = "Browse by Tags"
+[ui_tags_intro]
+other = "We've categorized the glossary terms. Use the filters to browse terms by tag."
+[ui_or_search_by_tags]
+other = "...or browse by tag"
+[ui_select_all]
+other = "Select All"
+[ui_deselect_all]
+other = "Deselect All"

--- a/website/layouts/_default/terms.html
+++ b/website/layouts/_default/terms.html
@@ -1,0 +1,48 @@
+{{ define "main" }}
+<div class="td-content">
+    <h1>{{ title ( T "ui_search_by_tags" ) }}</h1>
+
+    <p>{{ ( T "ui_tags_intro" ) }}</p>
+
+    <script src="{{ "js/tag-search.js" | relURL }}"></script>
+
+    {{ $tags := index .Site.Taxonomies "tags" }}
+
+    <div class="canonical-tag-container">
+        {{ range $tags }}
+            {{ $tagid := printf "tag-%s" ( replace .Page.Title " " "-" ) }}
+            <button id="{{ $tagid  }}" class="canonical-tag" data-target="{{ $tagid  }}">{{ title .Page.Title }}</button>
+        {{ end }}
+        <span><button class="button-reset-to-text" id="select-all-tags">{{ T "ui_select_all" }}</button></span>
+        <span><button class="button-reset-to-text" id="deselect-all-tags">{{ T "ui_deselect_all" }}</button></span>
+    </div>
+    
+    <div id="posts-by-tag">
+        {{ $sortedPages := sort .Site.Pages "Date" "desc" }}
+        {{ range $sortedPages }}
+            {{ if eq .Section "blog" }}
+                {{ $.Scratch.Set "tag_classes" "" }}
+                {{ range .Params.tags }}
+                    {{ with . }}
+                        {{ $.Scratch.Add "tag_classes" (printf "tag-%s " ( replace . " " "-" ) )  }}
+                    {{ end }}
+                {{ end }}
+                
+                <div class="mb-5 mt-5 {{ $.Scratch.Get "tag_classes" }} hide" data-show-count="0">
+                    <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+                    <div class="td-byline mb-3 mt-3 text-muted">
+                        {{ with .Params.author }}{{ T "post_byline_by" }} {{ . | markdownify }} |{{ end}}
+                        <time datetime="{{  .Date.Format "2006-01-02" }}" class="text-muted">{{ .Date.Format $.Site.Params.time_format_blog  }}</time>
+                    </div>                
+                    <div>
+                        <p>
+                        {{ .Summary }}..
+                        </p>
+                    </div>
+                </div>
+            {{ end }}
+        {{ end }}
+    </div>
+
+</div>
+{{ end }}

--- a/website/layouts/blog/content.html
+++ b/website/layouts/blog/content.html
@@ -1,23 +1,18 @@
 <div class="td-content">
+	{{ $context := . }}
+	{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" "categories" ) }}
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
-	<div class="td-byline mb-5 text-muted">
+	{{ $context := . }}
+	{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" "tags" ) }}
+	<div class="td-byline mb-5 mt-3 text-muted">
 		{{ with .Params.author }}{{ T "post_byline_by" }} {{ . | markdownify }} |{{ end}}
 		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-muted">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
 	</div>
-	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
-	    {{ partial "reading-time.html" . }}
-	{{ end }}
 	{{ .Content }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.Params.DisqusShortname) }}
-		<br />
-		{{ partial "disqus-comment.html" . }}
-		<br />
-	{{ end }}
-
 	{{ partial "pager.html" . }}
 </div>

--- a/website/layouts/partials/taxonomy_terms_article.html
+++ b/website/layouts/partials/taxonomy_terms_article.html
@@ -1,0 +1,15 @@
+{{ $context := .context  }}
+{{ $taxo := .taxo  }}
+{{ if (gt (len ($context.GetTerms $taxo)) 0)}}
+<div class="taxonomy taxonomy-terms-article taxo-{{ urlize $taxo }}">
+  <ul class="taxonomy-terms">
+    {{ range ($context.GetTerms $taxo) }}
+      {{ if eq $taxo "tags" }}
+        <li><a class="tax-term" href="{{ relref . "/tags" }}?{{ replace .LinkTitle " " "-" }}=true">{{ title .LinkTitle }}</a></li>
+      {{ else }}
+        <li><span class="tax-term">{{ title .LinkTitle }}</span></li>
+      {{ end }}
+    {{ end }}
+  </ul>
+</div>
+{{ end }}

--- a/website/static/js/tag-search.js
+++ b/website/static/js/tag-search.js
@@ -1,0 +1,154 @@
+// TODO (long-term): Would be easier to manage all this state with React
+
+$( document ).ready(function() {
+    var selectAllKey = "all";
+    var deselectAllKey = "none";
+  
+    var defaultActiveTag = "";
+    var activeTags = {};
+  
+    var paramSize = function(paramHash) {
+      return Object.keys(paramHash).length;
+    }
+  
+    // "Lib" for acquiring parameters from the URL
+    var urlParamLib = function() {
+      function initParams() {
+        var sPageURL = decodeURIComponent(window.location.search.substring(1)),
+          sURLVariables = sPageURL.split('&'),
+          sParameterName,
+          i;
+  
+        var paramHash = {};
+        for (i = 0; i < sURLVariables.length; i++) {
+          sParameterName = sURLVariables[i].split('=');
+          if (sParameterName[0] != "")
+            paramHash[sParameterName[0]] = sParameterName[1];
+        }
+  
+        if (paramSize(paramHash) == 0) {
+          paramHash[defaultActiveTag] = true;
+        }
+  
+        return paramHash;
+      }
+  
+      function updateParams(paramHash) {
+        var urlWithoutQuery = window.location.href.split('?')[0];
+        window.history.pushState(null,null, urlWithoutQuery + "?" + $.param(paramHash) + window.location.hash);
+      }
+  
+      return {
+        initParams: initParams,
+        updateParams: updateParams,
+      };
+    }();
+  
+    var initClickFunctions = function() {
+  
+      var deactivateTagTerms = function(elt) {
+        var targetTag = elt.data("target");
+        var targetClass = "." + targetTag;
+        var tagName = targetTag.split('tag-')[1];
+  
+        elt.removeClass("is-active");
+        $(targetClass).each(function(){
+          var showCount = $(this).data("show-count");
+          var newShowCount = showCount - 1;
+          $(this).data("show-count", newShowCount);
+          if (newShowCount < 1) {
+            $(this).addClass("hide");
+          }
+        });
+        delete activeTags[tagName];
+      };
+  
+      var activateTagTerms = function(elt) {
+        var targetTag = elt.data("target");
+        var targetClass = "." + targetTag;
+        var tagName = targetTag.split('tag-')[1];
+  
+        elt.addClass("is-active");
+        $(targetClass).each(function(){
+          var showCount = $(this).data("show-count");
+          var newShowCount = showCount + 1;
+          $(this).data("show-count", newShowCount);
+          if (newShowCount > 0) {
+            $(this).removeClass("hide");
+          }
+        });
+        activeTags[tagName] = true;
+        if (activeTags[deselectAllKey]) {
+          delete activeTags[deselectAllKey];
+        }
+      };
+  
+      // Shows/hides glossary terms when their relevant tags are clicked
+      $(".canonical-tag").each(function(){
+        var placeholder = $("#placeholder");
+        var targetTag = $(this).data("target");
+        $(this).mouseenter(function(){
+          var tagDescription = $("#" + targetTag + "-description").html();
+          placeholder.html(tagDescription);
+          placeholder.removeClass('invisible');
+        }).mouseleave(function(){
+          placeholder.addClass('invisible');
+        });
+  
+        $(this).click(function(){
+          var shouldHide = $(this).hasClass("is-active");
+          if (shouldHide) {
+            deactivateTagTerms($(this));
+          } else {
+            activateTagTerms($(this));
+          }
+          urlParamLib.updateParams(activeTags);
+        });
+      });
+  
+      // Adds functionality to "select all tags" link
+      $("#select-all-tags").click(function(){
+        $(".canonical-tag").each(function(){
+          var shouldActivate = !$(this).hasClass("is-active");
+          if (shouldActivate) {
+            activateTagTerms($(this));
+          }
+        });
+        queryParams = {}
+        queryParams[selectAllKey] = true;
+        urlParamLib.updateParams(queryParams);
+      });
+  
+      // Adds functionality to "deselect all tags" link
+      $("#deselect-all-tags").click(function(){
+        $(".canonical-tag").each(function(){
+          var shouldHide = $(this).hasClass("is-active");
+          if (shouldHide) {
+            deactivateTagTerms($(this));
+          }
+        });
+        queryParams = {}
+        queryParams[deselectAllKey] = true;
+        urlParamLib.updateParams(queryParams);
+      });
+  
+    };
+  
+    function initActiveTags() {
+      if (activeTags[selectAllKey]) {
+        $("#select-all-tags").click();
+      } else if (activeTags[deselectAllKey]) {
+        $("#deselect-all-tags").click();
+      } else {
+        for (var tagId in activeTags) {
+          $("#tag-" + tagId).click();
+        }
+      }
+    }
+  
+    initClickFunctions();
+    activeTags = urlParamLib.initParams();
+    initActiveTags();
+  
+  });
+  


### PR DESCRIPTION
Addresses #522 

Styles the tags and categories on [a blog post](https://deploy-preview-526--tag-app-delivery.netlify.app/blog/infrastructure-for-apps-platforms-for-cooperative-delivery/). Categories show above the title, tags below.

Click on a tag to access [the browse-by-tag screen](https://deploy-preview-526--tag-app-delivery.netlify.app/tags/?WG-Platforms=true). Click on the tag filters to turn on/off each filter.

Does this UX and design make sense to support the long-term vision of your tag and category use? 

I haven't done much with the categories, apart from showing them on each blog post page. Perhaps instead of the regular blog listing, we should have a separate listing for each category.

