### PR TITLE
Upgrade hugo and fix warnings

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -48,24 +48,27 @@ anchor = "smart"
 [languages]
 [languages.en]
 title = "CNCF TAG App Delivery"
-description = "TAG App Delivery focuses on enabling projects and initiatives related to delivering cloud-native applications, including building, deploying, managing, and operating them."
 languageName ="English"
 # Weight used for sorting.
 weight = 1
+[languages.en.params]
+description = "TAG App Delivery focuses on enabling projects and initiatives related to delivering cloud-native applications, including building, deploying, managing, and operating them."
 
 [languages.zh]
 title = "CNCF 应用交付 TAG"
-decscription = "应用交付 TAG 专注于支持与交付云原生应用程序相关的项目和计划，包括构建、部署、管理和运营。"
 languageName = "中文(Chinese)"
 contentDir = "content/zh"
 weight = 2
+[languages.zh.params]
+description = "应用交付 TAG 专注于支持与交付云原生应用程序相关的项目和计划，包括构建、部署、管理和运营。"
 
 [languages.ko]
 title = "CNCF 앱 딜리버리 TAG"
-description = "앱 딜리버리 TAG(Technology Advisory Group, 기술 자문 그룹)는 빌딩, 배포, 관리, 운영을 포함하여 클라우드 네이티브 애플리케이션 딜리버리에 관련된 프로젝트와 이니셔티브를 활성화하는 데 중점을 둔다."
 languageName = "한국어(Korean)"
 contentDir = "content/ko"
 weight = 3
+[languages.ko.params]
+description = "앱 딜리버리 TAG(Technology Advisory Group, 기술 자문 그룹)는 빌딩, 배포, 관리, 운영을 포함하여 클라우드 네이티브 애플리케이션 딜리버리에 관련된 프로젝트와 이니셔티브를 활성화하는 데 중점을 둔다."
 
 [languages.ja]
 title = "CNCF TAG Appデリバリー"

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,4 +1,4 @@
 [build]
 [build.environment]
-HUGO_VERSION = "0.104.3"
-GO_VERSION = "1.19.2"
+HUGO_VERSION = "0.121.1"
+GO_VERSION = "1.21.5"


### PR DESCRIPTION
```
$ hugo server -D
WARN  DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" instead.
WARN  deprecated: config: languages.ko.description: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below [languages.ko.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN  deprecated: config: languages.en.description: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN  deprecated: config: languages.zh.decscription: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below [languages.zh.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
```