### PR TITLE
Add keycloak to example CNCF/CDF projects in the translated platforms whitepapers

### DIFF
--- a/website/content/ja/wgs/platforms/whitepaper/index.md
+++ b/website/content/ja/wgs/platforms/whitepaper/index.md
@@ -482,7 +482,7 @@ relating it to existing CNCF or CDF projects.
   <tr>
     <td>Identity and secret services</td>
     <td>Ensure workloads have locators and secrets to use resources and capabilities. Enable services to identify themselves to other services</td>
-    <td>Dex, External Secrets, SPIFFE/SPIRE, Teller, cert-manager</td>
+    <td>Keycloak, Dex, External Secrets, SPIFFE/SPIRE, Teller, cert-manager</td>
   </tr>
   <tr>
     <td>Security services</td>

--- a/website/content/ko/wgs/platforms/whitepaper/index.md
+++ b/website/content/ko/wgs/platforms/whitepaper/index.md
@@ -482,7 +482,7 @@ relating it to existing CNCF or CDF projects.
   <tr>
     <td>Identity and secret services</td>
     <td>Ensure workloads have locators and secrets to use resources and capabilities. Enable services to identify themselves to other services</td>
-    <td>Dex, External Secrets, SPIFFE/SPIRE, Teller, cert-manager</td>
+    <td>Keycloak, Dex, External Secrets, SPIFFE/SPIRE, Teller, cert-manager</td>
   </tr>
   <tr>
     <td>Security services</td>

--- a/website/content/zh/wgs/platforms/whitepaper/index.md
+++ b/website/content/zh/wgs/platforms/whitepaper/index.md
@@ -242,7 +242,7 @@ type: whitepapers
   <tr>
     <td>身份和秘密服务</td>
     <td>确保工作负载具有定位信息和用于访问资源和功能的秘密。使服务能够向其他服务标识自己</td>
-    <td>Dex、External Secrets、SPIFFE/SPIRE、Teller、cert-manager</td>
+    <td>Keycloak, Dex、External Secrets、SPIFFE/SPIRE、Teller、cert-manager</td>
   </tr>
   <tr>
     <td>安全服务</td>


### PR DESCRIPTION
This PR adds keycloak to example CNCF/CDF projects in the translated platforms whitepapers.
Put another way; it applies the same changes as https://github.com/cncf/tag-app-delivery/pull/524 to the white papers in other languages.

PR Status:

- [x] Ready for code owner review