### PR TITLE
Update References link in Operator-WhitePaper_v1-0.md

### DIFF
--- a/operator-wg/whitepaper/Operator-WhitePaper_v1-0.md
+++ b/operator-wg/whitepaper/Operator-WhitePaper_v1-0.md
@@ -315,7 +315,7 @@ about if they should use an operator:
 
 For further ideas around the security of the development process,
 the reader may wish to review the CNCF Security TAG's [self-assessment
-questionnaire](https://github.com/cncf/sig-security/blob/master/assessments/guide/self-assessment.md).
+questionnaire](https://github.com/cncf/tag-security/blob/main/assessments/guide/self-assessment.md).
 
 #### Operator Scope
 

--- a/operator-wg/whitepaper/Operator-WhitePaper_v1-0.md
+++ b/operator-wg/whitepaper/Operator-WhitePaper_v1-0.md
@@ -358,13 +358,13 @@ Being focused on the development and security of the operator,
 there are steps that must be taken as an operator developer to ensure
 validation and proper security analysis has been done. Following the
 guidelines in the CNCF Cloud Native Security Whitepaper there is a
-clear lifecycle process which defines the [layers of concern](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
+clear lifecycle process which defines the [layers of concern](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
 should be adhered to with a strict focus on the develop and distribute
 layers in the scope of the operator developer. There are many detailed
 guidelines in the development and distribution layers that will help
 to apply sound vulnerability analysis to supply chain to ensure
 that the operator being developed is signed and trusted for the best
-integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md)
+integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md)
 is available at this link.
 
 In addition to the supply chain there needs to be a focus on
@@ -372,7 +372,7 @@ performing a threat model of the operator to keep the developer
 in check and also make sure that there was nothing incidentally missed
 that could leave the door open for attack. The foundational model for
 checking for threats can be observed in the CNCF Cloud Native Security
-Whitepaper on [Threat Modeling](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#threat-modeling).
+Whitepaper on [Threat Modeling](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#threat-modeling).
 
 ### Application Developer (Operator-"Users")
 
@@ -973,7 +973,7 @@ The CNCF TAG Security spent a lot of effort to add security related topics to th
 \[4\] https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps
 \[5\] Operator Framework. Retrieved 11 2020, 24, from https://operatorframework.io/operator-capabilities/,
 https://github.com/cloud-ark/kubeplus/blob/master/Guidelines.md
-\[6\] https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md
+\[6\] https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md
 
 
 ## Acknowledgements

--- a/operator-whitepaper/latest/index.md
+++ b/operator-whitepaper/latest/index.md
@@ -354,7 +354,7 @@ about if they should use an operator:
 
 For further ideas around the security of the development process,
 the reader may wish to review the CNCF Security TAG's [self-assessment
-questionnaire](https://github.com/cncf/sig-security/blob/master/assessments/guide/self-assessment.md).
+questionnaire](https://github.com/cncf/tag-security/blob/main/assessments/guide/self-assessment.md).
 
 #### Operator Scope
 

--- a/operator-whitepaper/latest/index.md
+++ b/operator-whitepaper/latest/index.md
@@ -397,13 +397,13 @@ Being focused on the development and security of the operator,
 there are steps that must be taken as an operator developer to ensure
 validation and proper security analysis has been done. Following the
 guidelines in the CNCF Cloud Native Security Whitepaper there is a
-clear lifecycle process which defines the [layers of concern](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
+clear lifecycle process which defines the [layers of concern](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
 should be adhered to with a strict focus on the develop and distribute
 layers in the scope of the operator developer. There are many detailed
 guidelines in the development and distribution layers that will help
 to apply sound vulnerability analysis to supply chain to ensure
 that the operator being developed is signed and trusted for the best
-integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md)
+integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md)
 is available at this link.
 
 In addition to the supply chain there needs to be a focus on
@@ -411,7 +411,7 @@ performing a threat model of the operator to keep the developer
 in check and also make sure that there was nothing incidentally missed
 that could leave the door open for attack. The foundational model for
 checking for threats can be observed in the CNCF Cloud Native Security
-Whitepaper on [Threat Modeling](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#threat-modeling).
+Whitepaper on [Threat Modeling](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#threat-modeling).
 
 ### Application Developer (Operator-"Users")
 
@@ -1119,7 +1119,7 @@ The CNCF TAG Security spent a lot of effort to add security related topics to th
 \[4\] https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps
 \[5\] Operator Framework. Retrieved 11 2020, 24, from https://operatorframework.io/operator-capabilities/,
 https://github.com/cloud-ark/kubeplus/blob/master/Guidelines.md
-\[6\] https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md
+\[6\] https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md
 
 
 ## Acknowledgements

--- a/operator-whitepaper/v1/Operator-WhitePaper_v1-0.md
+++ b/operator-whitepaper/v1/Operator-WhitePaper_v1-0.md
@@ -315,7 +315,7 @@ about if they should use an operator:
 
 For further ideas around the security of the development process,
 the reader may wish to review the CNCF Security TAG's [self-assessment
-questionnaire](https://github.com/cncf/sig-security/blob/master/assessments/guide/self-assessment.md).
+questionnaire](https://github.com/cncf/tag-security/blob/main/assessments/guide/self-assessment.md).
 
 #### Operator Scope
 

--- a/operator-whitepaper/v1/Operator-WhitePaper_v1-0.md
+++ b/operator-whitepaper/v1/Operator-WhitePaper_v1-0.md
@@ -973,8 +973,7 @@ The CNCF TAG Security spent a lot of effort to add security related topics to th
 \[4\] https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps
 \[5\] Operator Framework. Retrieved 11 2020, 24, from https://operatorframework.io/operator-capabilities/,
 https://github.com/cloud-ark/kubeplus/blob/master/Guidelines.md
-\[6\] https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md
-
+\[6\] https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md
 
 ## Acknowledgements
 This document is a community-driven effort of the CNCF TAG App-Delivery Operator Working Group. Thanks to everyone who contributed to this document, joined discussions and reviewed this document.

--- a/operator-whitepaper/v1/Operator-WhitePaper_v1-0.md
+++ b/operator-whitepaper/v1/Operator-WhitePaper_v1-0.md
@@ -358,13 +358,13 @@ Being focused on the development and security of the operator,
 there are steps that must be taken as an operator developer to ensure
 validation and proper security analysis has been done. Following the
 guidelines in the CNCF Cloud Native Security Whitepaper there is a
-clear lifecycle process which defines the [layers of concern](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
+clear lifecycle process which defines the [layers of concern](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
 should be adhered to with a strict focus on the develop and distribute
 layers in the scope of the operator developer. There are many detailed
 guidelines in the development and distribution layers that will help
 to apply sound vulnerability analysis to supply chain to ensure
 that the operator being developed is signed and trusted for the best
-integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md)
+integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md)
 is available at this link.
 
 In addition to the supply chain there needs to be a focus on
@@ -372,7 +372,7 @@ performing a threat model of the operator to keep the developer
 in check and also make sure that there was nothing incidentally missed
 that could leave the door open for attack. The foundational model for
 checking for threats can be observed in the CNCF Cloud Native Security
-Whitepaper on [Threat Modeling](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#threat-modeling).
+Whitepaper on [Threat Modeling](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#threat-modeling).
 
 ### Application Developer (Operator-"Users")
 

--- a/operator-whitepaper/v1/_archive/raw/04_Security.md
+++ b/operator-whitepaper/v1/_archive/raw/04_Security.md
@@ -183,4 +183,3 @@ your environment. While it may seem like unnecessary work to learn
 configuration  parameters of a new operator, it is usually preferable
 manually adjusting the configuration and/or source code of an
 operator itself to reach the needed level of security.
-

--- a/operator-whitepaper/v1/_archive/raw/04_Security.md
+++ b/operator-whitepaper/v1/_archive/raw/04_Security.md
@@ -75,13 +75,13 @@ Since we are focused on the development and security of the operator
 there are steps you can take as an operator developer to ensure 
 validation and proper security analysis has been done. Following the
 guidelines in the CNCF Cloud Native Security Whitepaper there is a 
-clear lifecycle process which defines the [layers of concern](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
+clear lifecycle process which defines the [layers of concern](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
 should be adhered to with a strict focus on the develop and distribute
 layers in the scope of the operator developer. There are many detailed
 guidelines in the development and distribution layers that will help 
 to apply sound vulnerability analysis to your supply chain to ensure
 that the operator being developed is signed and trusted for the best 
-integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md)
+integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md)
 is available at this link.  
   
 In addition to your supply chain you will also want to focus on 
@@ -89,7 +89,7 @@ performing a threat model of the operator to keep you as the developer
 in check and also make sure that you didn’t incidentally miss something
 that could leave the door open for attack. The foundational model for
 checking for threats can be observed in the CNCF Cloud Native Security
-Whitepaper on [Threat Modeling](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#threat-modeling).  
+Whitepaper on [Threat Modeling](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#threat-modeling).  
 
 ### Application Developer ("users")
 

--- a/operator-whitepaper/v1/_archive/raw/11_Related_Work.md
+++ b/operator-whitepaper/v1/_archive/raw/11_Related_Work.md
@@ -21,4 +21,4 @@ Many documents describe capability levels (also known as maturity levels) of ope
 Ref: Operator Framework. (n.d.). Operator Capabilities. Operator Framework. Retrieved 11 2020, 24, from https://operatorframework.io/operator-capabilities/,
 https://github.com/cloud-ark/kubeplus/blob/master/Guidelines.md
 
-The CNCF SIG Security spent a lot of effort to add security related topics to this whitepaper. As the content of this whitepaper should mostly cover operator-related security measures, they wrote a cloud native security whitepaper which is a very useful source when dealing with cloud native security (https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md).
+The CNCF TAG Security spent a lot of effort to add security related topics to this whitepaper. As the content of this whitepaper should mostly cover operator-related security measures, they wrote a cloud native security whitepaper which is a very useful source when dealing with cloud native security (https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md).

--- a/website/content/ja/wgs/operator/whitepaper/index.md
+++ b/website/content/ja/wgs/operator/whitepaper/index.md
@@ -353,7 +353,7 @@ about if they should use an operator:
 
 For further ideas around the security of the development process,
 the reader may wish to review the CNCF Security TAG's [self-assessment
-questionnaire](https://github.com/cncf/sig-security/blob/master/assessments/guide/self-assessment.md).
+questionnaire](https://github.com/cncf/tag-security/blob/main/assessments/guide/self-assessment.md).
 
 #### Operator Scope
 

--- a/website/content/ja/wgs/operator/whitepaper/index.md
+++ b/website/content/ja/wgs/operator/whitepaper/index.md
@@ -396,13 +396,13 @@ Being focused on the development and security of the operator,
 there are steps that must be taken as an operator developer to ensure
 validation and proper security analysis has been done. Following the
 guidelines in the CNCF Cloud Native Security Whitepaper there is a
-clear lifecycle process which defines the [layers of concern](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
+clear lifecycle process which defines the [layers of concern](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper-ja.md#cloud-native-layers) for the operator developer. All three layers
 should be adhered to with a strict focus on the develop and distribute
 layers in the scope of the operator developer. There are many detailed
 guidelines in the development and distribution layers that will help
 to apply sound vulnerability analysis to supply chain to ensure
 that the operator being developed is signed and trusted for the best
-integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md)
+integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper-ja.md)
 is available at this link.
 
 In addition to the supply chain there needs to be a focus on
@@ -410,7 +410,7 @@ performing a threat model of the operator to keep the developer
 in check and also make sure that there was nothing incidentally missed
 that could leave the door open for attack. The foundational model for
 checking for threats can be observed in the CNCF Cloud Native Security
-Whitepaper on [Threat Modeling](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#threat-modeling).
+Whitepaper on [Threat Modeling](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper-ja.md#threat-modeling).
 
 ### Application Developer (Operator-"Users")
 
@@ -1118,7 +1118,7 @@ The CNCF TAG Security spent a lot of effort to add security related topics to th
 \[4\] https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps
 \[5\] Operator Framework. Retrieved 11 2020, 24, from https://operatorframework.io/operator-capabilities/,
 https://github.com/cloud-ark/kubeplus/blob/master/Guidelines.md
-\[6\] https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md
+\[6\] https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper-ja.md
 
 
 ## Acknowledgements

--- a/website/content/ko/wgs/operator/whitepaper/index.md
+++ b/website/content/ko/wgs/operator/whitepaper/index.md
@@ -396,13 +396,13 @@ Being focused on the development and security of the operator,
 there are steps that must be taken as an operator developer to ensure
 validation and proper security analysis has been done. Following the
 guidelines in the CNCF Cloud Native Security Whitepaper there is a
-clear lifecycle process which defines the [layers of concern](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
+clear lifecycle process which defines the [layers of concern](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
 should be adhered to with a strict focus on the develop and distribute
 layers in the scope of the operator developer. There are many detailed
 guidelines in the development and distribution layers that will help
 to apply sound vulnerability analysis to supply chain to ensure
 that the operator being developed is signed and trusted for the best
-integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md)
+integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md)
 is available at this link.
 
 In addition to the supply chain there needs to be a focus on
@@ -410,7 +410,7 @@ performing a threat model of the operator to keep the developer
 in check and also make sure that there was nothing incidentally missed
 that could leave the door open for attack. The foundational model for
 checking for threats can be observed in the CNCF Cloud Native Security
-Whitepaper on [Threat Modeling](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#threat-modeling).
+Whitepaper on [Threat Modeling](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#threat-modeling).
 
 ### Application Developer (Operator-"Users")
 
@@ -1118,7 +1118,7 @@ The CNCF TAG Security spent a lot of effort to add security related topics to th
 \[4\] https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps
 \[5\] Operator Framework. Retrieved 11 2020, 24, from https://operatorframework.io/operator-capabilities/,
 https://github.com/cloud-ark/kubeplus/blob/master/Guidelines.md
-\[6\] https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md
+\[6\] https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md
 
 
 ## Acknowledgements

--- a/website/content/ko/wgs/operator/whitepaper/index.md
+++ b/website/content/ko/wgs/operator/whitepaper/index.md
@@ -353,7 +353,7 @@ about if they should use an operator:
 
 For further ideas around the security of the development process,
 the reader may wish to review the CNCF Security TAG's [self-assessment
-questionnaire](https://github.com/cncf/sig-security/blob/master/assessments/guide/self-assessment.md).
+questionnaire](https://github.com/cncf/tag-security/blob/main/assessments/guide/self-assessment.md).
 
 #### Operator Scope
 

--- a/website/content/zh/wgs/operator/whitepaper/index.md
+++ b/website/content/zh/wgs/operator/whitepaper/index.md
@@ -353,7 +353,7 @@ about if they should use an operator:
 
 For further ideas around the security of the development process,
 the reader may wish to review the CNCF Security TAG's [self-assessment
-questionnaire](https://github.com/cncf/sig-security/blob/master/assessments/guide/self-assessment.md).
+questionnaire](https://github.com/cncf/tag-security/blob/main/assessments/guide/self-assessment.md).
 
 #### Operator Scope
 

--- a/website/content/zh/wgs/operator/whitepaper/index.md
+++ b/website/content/zh/wgs/operator/whitepaper/index.md
@@ -396,13 +396,13 @@ Being focused on the development and security of the operator,
 there are steps that must be taken as an operator developer to ensure
 validation and proper security analysis has been done. Following the
 guidelines in the CNCF Cloud Native Security Whitepaper there is a
-clear lifecycle process which defines the [layers of concern](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#cloud-native-layers) for the operator developer. All three layers
+clear lifecycle process which defines the [layers of concern](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper-simplified-chinese.md#cloud-native-layers) for the operator developer. All three layers
 should be adhered to with a strict focus on the develop and distribute
 layers in the scope of the operator developer. There are many detailed
 guidelines in the development and distribution layers that will help
 to apply sound vulnerability analysis to supply chain to ensure
 that the operator being developed is signed and trusted for the best
-integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md)
+integrity. The CNCF [Cloud Native Security Whitepaper](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper-simplified-chinese.md)
 is available at this link.
 
 In addition to the supply chain there needs to be a focus on
@@ -410,7 +410,7 @@ performing a threat model of the operator to keep the developer
 in check and also make sure that there was nothing incidentally missed
 that could leave the door open for attack. The foundational model for
 checking for threats can be observed in the CNCF Cloud Native Security
-Whitepaper on [Threat Modeling](https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md#threat-modeling).
+Whitepaper on [Threat Modeling](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper-simplified-chinese.md#threat-modeling).
 
 ### Application Developer (Operator-"Users")
 
@@ -1118,7 +1118,7 @@ The CNCF TAG Security spent a lot of effort to add security related topics to th
 \[4\] https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps
 \[5\] Operator Framework. Retrieved 11 2020, 24, from https://operatorframework.io/operator-capabilities/,
 https://github.com/cloud-ark/kubeplus/blob/master/Guidelines.md
-\[6\] https://github.com/cncf/sig-security/blob/master/security-whitepaper/cloud-native-security-whitepaper.md
+\[6\] https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper-simplified-chinese.md
 
 
 ## Acknowledgements


### PR DESCRIPTION
Resolving issue reported here: https://github.com/cncf/tag-app-delivery/issues/544

Correcting link to paper in the "References" section.