### PR TITLE
chore: Update TAG Leads

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -20,9 +20,6 @@ collaborators:
   - username: kgamanji
     permission: admin
 
-  - username: justincormack
-    permission: admin
-
   # TAG Chairs (all have admin access)
   - username: AloisReitbauer
     permission: admin
@@ -34,7 +31,7 @@ collaborators:
     permission: admin
 
   # Tech Leads (all have maintain access)
-  - username: AlexsJones
+  - username: angellk
     permission: maintain
 
   - username: lianmakesthings

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,13 +10,13 @@
 #
 # Unless a later match takes precedence, these owners will be requested for
 # review when someone opens a pull request.
-*   @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings @kgamanji @justincormack @angellk
+*   @AloisReitbauer @thschue @joshgav @lianmakesthings @kgamanji @angellk
 
 # Platforms WG
-/platforms-*/ @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings @kgamanji @justincormack @angellk @abangser @roberthstrand @joshgav
+/platforms-*/ @AloisReitbauer @thschue @joshgav @lianmakesthings @kgamanji  @angellk @abangser @roberthstrand
 
 # GitOps WG
-/gitops-*/ @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings @kgamanji @justincormack @angellk @todaywasawesome @chris-short @scottrigby
+/gitops-*/ @AloisReitbauer @thschue @joshgav @lianmakesthings @kgamanji @angellk @todaywasawesome @chris-short @scottrigby
 
 # Artifacts WG
-/artifacts-*/ @AloisReitbauer @AlexsJones @thschue @joshgav @lianmakesthings @kgamanji @justincormack @angellk @sabre1041 @rchincha
+/artifacts-*/ @AloisReitbauer @thschue @joshgav @lianmakesthings @kgamanji @angellk @sabre1041 @rchincha

--- a/README.md
+++ b/README.md
@@ -31,18 +31,17 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 - Alois Reitbauer (@AloisReitbauer) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
 - Josh Gavant (@joshgav) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
-- Thomas Schuetz (@thschue) (Co-Chair, Term: 2023/08/30 - 2023/08/29)
-- Alex Jones (@alexsjones) (TL)
+- Thomas Schuetz (@thschue) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
 - Lian Li (@lianmakesthings) (TL)
 - Karena Angell (@angellk) (TL)
 
 ## TOC Liaisons
 - Katie Gamanji (@kgamanji)
-- Justin Cormack (@justincormack)
 
 ## Emeritus Leads
 - Jennifer Strejevitch (@Jenninha)
 - Hongchao Deng (@hongchaodeng)
+- Alex Jones (@AlexsJones)
 
 ## Working Groups
 


### PR DESCRIPTION
## This PR
* Removes @AlexsJones from TLs
* Removes @justincormack from TAG Liaisons

Thanks to @AlexsJones and @justincormack for your contributions!