### PR TITLE
Clean-up: Update settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,5 +11,5 @@ repository:
   homepage: https://cncf.io/projects
   
   # Collaborators: give specific users access to this repository.
-  # Note that the permissions are controlled in the https://github.com/cncf/people/blob/main/config.yaml file
+  # Note that the permissions are controlled using CLOWarden in the https://github.com/cncf/people/blob/main/config.yaml file
   # Please create a PR in the https://github.com/cncf/people/ repo to change user access

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,53 +11,5 @@ repository:
   homepage: https://cncf.io/projects
   
   # Collaborators: give specific users access to this repository.
-  # see /governance/roles.md for details on write access policy
-  # note that the permissions below may provide wider access than needed for
-  # a specific role, and we trust these individuals to act according to their
-  # role. If there are questions, please contact one of the chairs.
-collaborators:
-  # TOC Liasons (all have admin access)
-  - username: kgamanji
-    permission: admin
-
-  # TAG Chairs (all have admin access)
-  - username: AloisReitbauer
-    permission: admin
-
-  - username: thschue
-    permission: admin
-    
-  - username: joshgav
-    permission: admin
-
-  # Tech Leads (all have maintain access)
-  - username: angellk
-    permission: maintain
-
-  - username: lianmakesthings
-    permission: maintain
-
-  # GitOps WG Chairs (all have push access)
-  - username: todaywasawesome
-    permission: push
-
-  - username: scottrigby
-    permission: push
-
-  - username: chris-short
-    permission: push
-
-  # Platforms WG Chairs (all have push access)
-  - username: roberthstrand
-    permission: push
-
-  - username: abangser
-    permission: push
-
-  # Artifacts WG Chairs (all have push access)
-  - username: afflom
-    permission: push
-  - username: rchincha
-    permission: push
-
-    
+  # Note that the permissions are controlled in the https://github.com/cncf/people/blob/main/config.yaml file
+  # Please create a PR in the https://github.com/cncf/people/ repo to change user access


### PR DESCRIPTION
People and permissions have been moved to the [cncf/people/config.yml file](https://github.com/cncf/people/blob/main/config.yaml) making permissions in the local settings.yml file redundant.

Proposed updates:

- [x]  Remove the people from the local settings.yml
- [x]  Add a link in the setting.yml to the [cncf/people/config.yml file](https://github.com/cncf/people/blob/main/config.yaml#L816) for clarity