### PR TITLE
Introduce a GitHub Action That Sends a Message to a PR to Notify i18n Tasks.

### DIFF
--- a/.github/workflows/deep-diff.sh
+++ b/.github/workflows/deep-diff.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# This script lists files that have been added or edited under a specified directory,
+# including the targets of any symlinks.
+
+set -e
+
+if [ "$#" -ne 1 ] && [ "$#" -ne 3 ]; then
+    echo "The number of arguments must be either 1 or 3."
+    echo "Usage: ./list-targets.sh [path] <[commit] [commit]>"
+    exit 1
+fi
+
+if [ "$#" -eq 1 ]; then
+  git diff --name-only "$1"
+else
+  git diff --name-only "$2" "$3" "$1"
+fi
+
+# Differences in targets of symbolic links.
+symlinks=$(find "$1" -type l)
+for l in ${symlinks}; do
+  linktarget=$(readlink -f "${l}")
+
+  if [ "$#" -eq 1 ]; then
+    git diff --name-only "$(realpath --relative-to=. "${linktarget}")"
+  else
+    git diff --name-only "$2" "$3" "$(realpath --relative-to=. "${linktarget}")"
+  fi
+done

--- a/.github/workflows/deep-diff.sh
+++ b/.github/workflows/deep-diff.sh
@@ -4,26 +4,17 @@
 
 set -e
 
-if [ "$#" -ne 1 ] && [ "$#" -ne 3 ]; then
-    echo "The number of arguments must be either 1 or 3."
-    echo "Usage: ./list-targets.sh [path] <[commit] [commit]>"
+if [ "$#" -ne 3 ]; then
+    echo "The number of arguments must be 3." >&2
+    echo "Usage: ./list-targets.sh [path] [commit-before] [commit-after]" >&2
     exit 1
 fi
 
-if [ "$#" -eq 1 ]; then
-  git diff --name-only "$1"
-else
-  git diff --name-only "$2" "$3" "$1"
-fi
+git diff --name-only "$2" "$3" "$1"
 
 # Differences in targets of symbolic links.
 symlinks=$(find "$1" -type l)
 for l in ${symlinks}; do
-  linktarget=$(readlink -f "${l}")
-
-  if [ "$#" -eq 1 ]; then
-    git diff --name-only "$(realpath --relative-to=. "${linktarget}")"
-  else
+    linktarget=$(readlink -f "${l}")
     git diff --name-only "$2" "$3" "$(realpath --relative-to=. "${linktarget}")"
-  fi
 done

--- a/.github/workflows/deep-diff.sh
+++ b/.github/workflows/deep-diff.sh
@@ -6,7 +6,7 @@ set -e
 
 if [ "$#" -ne 3 ]; then
     echo "The number of arguments must be 3." >&2
-    echo "Usage: ./list-targets.sh [path] [commit-before] [commit-after]" >&2
+    echo "Usage: ./deep-diff.sh [path] [commit-before] [commit-after]" >&2
     exit 1
 fi
 

--- a/.github/workflows/notice-i18n-tasks.yml
+++ b/.github/workflows/notice-i18n-tasks.yml
@@ -1,0 +1,41 @@
+name: Notice i18n Tasks
+on:
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+
+jobs:
+  notice-i18n-tasks:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+
+    - name : Check the diffs when the issue is opened
+      id: diff-check-opened
+      if: github.event.action == 'opened' || github.event.action == 'reopened'
+      run: |
+        echo "diff-count=$(.github/workflows/deep-diff.sh hoge | wc -l)" >> $GITHUB_OUTPUT
+
+    - name: Check the diffs when the content in the PR updated
+      id: diff-check-updated
+      if: github.event.action == 'synchronize'
+      run: |
+        echo "diff-count=$(.github/workflows/deep-diff.sh hoge ${{ github.event.before }} ${{ github.event.after }} | wc -l)" >> $GITHUB_OUTPUT
+
+    - name: Send notice on the issue
+      if: steps.diff-check-opened.outputs.diff-count > 0 || steps.diff-check-updated.outputs.diff-count > 0
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |
+          ### Action Required
+          You are adding or updating English content so please take the following actions for other languages.
+          - If you add new content under `website/content/en` or targets of the symbolic links in the same directory, please replicate it in the corresponding directories of all other languages. (e.g. If you create `website/content/en/blog/new-post.md`, you should copy it to `website/content/ja/blog/new-post.md`, etc.)
+          - If you update the content in the same location, please perform the following actions for the corresponding content in other languages.
+            - If the content has not been translated yet, replace the files with the updated English version.
+            - If the content has already been translated, include a note suggesting that users check the English page for the most recent updates.

--- a/.github/workflows/notice-i18n-tasks.yml
+++ b/.github/workflows/notice-i18n-tasks.yml
@@ -25,6 +25,7 @@ jobs:
       id: check-diffs
       run: |
         updated_files="$(.github/workflows/deep-diff.sh website/content/en ${{ github.sha }} ${{ github.event.pull_request.head.sha }})"
+        echo "${updated_files}" # for debugging
         echo "count=$(echo $updated_files | grep -v '^$' | wc -l)" >> $GITHUB_OUTPUT
 
     - name: Send notice on the issue

--- a/.github/workflows/notice-i18n-tasks.yml
+++ b/.github/workflows/notice-i18n-tasks.yml
@@ -1,6 +1,6 @@
 name: Notice i18n Tasks
 on:
-  pull_request:
+  pull_request_target:
     types:
     - opened
     - reopened
@@ -9,29 +9,29 @@ on:
 jobs:
   notice-i18n-tasks:
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
     steps:
-    - name: Check out
+    - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
 
-    - name : Check the diffs when the issue is opened
-      id: diff-check-opened
-      if: github.event.action == 'opened' || github.event.action == 'reopened'
+    - name: Check diffs
+      id: check-diffs
       run: |
-        echo "diff-count=$(.github/workflows/deep-diff.sh hoge | wc -l)" >> $GITHUB_OUTPUT
-
-    - name: Check the diffs when the content in the PR updated
-      id: diff-check-updated
-      if: github.event.action == 'synchronize'
-      run: |
-        echo "diff-count=$(.github/workflows/deep-diff.sh hoge ${{ github.event.before }} ${{ github.event.after }} | wc -l)" >> $GITHUB_OUTPUT
+        updated_files="$(.github/workflows/deep-diff.sh website/content/en ${{ github.sha }} ${{ github.event.pull_request.head.sha }})"
+        echo "count=$(echo $updated_files | grep -v '^$' | wc -l)" >> $GITHUB_OUTPUT
 
     - name: Send notice on the issue
-      if: steps.diff-check-opened.outputs.diff-count > 0 || steps.diff-check-updated.outputs.diff-count > 0
+      if: steps.check-diffs.outputs.count > 0
       uses: thollander/actions-comment-pull-request@v2
       with:
+        comment_tag: i18n-notice
         message: |
           ### Action Required
           You are adding or updating English content so please take the following actions for other languages.


### PR DESCRIPTION
This PR adds a GitHub Action that sends a message to a PR to notify i18n tasks following the discussion in https://github.com/cncf/tag-app-delivery/issues/537 .

### Background
Currently, when adding English content (files under `website/content/en/` ), we place a copy in the corresponding directories of other languages. This approach ensures that if there is no translated version available when browsing in different languages, the English content is displayed. Additionally, when updates are made, the same changes need to be applied to the corresponding files in other languages.

Our website's i18n support is relatively new, so this task is often overlooked. To prevent such oversights, This PR introduces a GitHub Action that would serve as a reminder.

### To reviewers
At the time of opening this PR, the GitHub Action implementation is still in draft, but I would appreciate your feedback on the following points:
- It detects changes under `website/content/en` and the targets of symbolic links; is there any other area that should be covered?
- Is the content of the message appropriate?

### Related Issues and PRs
- https://github.com/cncf/tag-app-delivery/issues/537
- https://github.com/cncf/tag-app-delivery/pull/545
- https://github.com/cncf/tag-app-delivery/pull/571