### PR TITLE
Try "exit 1" in both netlify.toml files to force all builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "exit 1"
+ignore = "exit 1"

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,4 +1,6 @@
 [build]
+ignore = "exit 1"
+
 [build.environment]
 HUGO_VERSION = "0.121.1"
 GO_VERSION = "1.21.5"


### PR DESCRIPTION
Builds are still being cancelled by netlifiy. It's not clear to me where the netlify.toml with the "exit 1" command should go so am trying it in both netlify.toml files, in root and in /website/.