### PR TITLE
update link to charter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for considering contributing to CNCF's TAG App Delivery! Here we'll describe some options you can pursue. Ultimately our work is defined by the passion and commitment of our contributors, so seek something valuable to you and valuable to the community and pursue it! Consider opening [a GitHub issue](https://github.com/cncf/tag-app-delivery/issues/new) to let everyone know about and support your work.
 
-Also consider reviewing [TAG App Delivery's charter](https://github.com/cncf/toc/blob/main/tags/app-delivery.md) to be sure your work is in scope.
+Also consider reviewing [TAG App Delivery's charter](https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.md) to be sure your work is in scope.
 
 ## Opportunities
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and operating them. The TAG produces guidance for and gathers feedback from
 cloud app users and developers and provides guidance and coordination to CNCF
 projects in the TAG's technical domains.
 
-Full charter here: <https://github.com/cncf/toc/blob/main/tags/app-delivery.md>
+Full charter here: <https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.md>
 
 ## Community
 

--- a/artifacts-wg/charter/charter.md
+++ b/artifacts-wg/charter/charter.md
@@ -39,6 +39,6 @@ The working group intends to carry out (but is not limited to) the following:
 * Demonstrate via prototypes the use of published schemas to facilitate query and analysis of bundles and content.
 
 [1]: https://artifacthub.io/docs/topics/repositories/
-[2]: https://github.com/cncf/toc/blob/main/tags/app-delivery.md#areas-considered-in-scope
+[2]: https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.mdp-delivery.md#areas-considered-in-scope
 [3]: https://artifacthub.io/docs/topics/repositories/
 [4]: https://knative.dev/docs/concepts/duck-typing/ 

--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -52,7 +52,7 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 ### Additional Resources
 
-- [TAG Charter](https://github.com/cncf/toc/blob/main/tags/app-delivery.md)
+- [TAG Charter](https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.md)
 - Slack channel: [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5)
     - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
 - [Mailing list](https://lists.cncf.io/g/cncf-tag-app-delivery/topics)

--- a/website/content/es/_index.md
+++ b/website/content/es/_index.md
@@ -52,7 +52,7 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 ### Additional Resources
 
-- [TAG Charter](https://github.com/cncf/toc/blob/main/tags/app-delivery.md)
+- [TAG Charter](https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.md)
 - Slack channel: [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5)
     - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
 - [Mailing list](https://lists.cncf.io/g/cncf-tag-app-delivery/topics)

--- a/website/content/ja/_index.md
+++ b/website/content/ja/_index.md
@@ -41,7 +41,7 @@ TAG Appデリバリーは、クラウドネイティブ・アプリケーショ�
 
 ### その他の資料
 
-- [TAGのチャーター](https://github.com/cncf/toc/blob/main/tags/app-delivery.md)
+- [TAGのチャーター](https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.md)
 - Slackチャンネル: [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5)
     - [CNCF Slackにご自身を招待する](https://slack.cncf.io/)
 - [メーリングリスト](https://lists.cncf.io/g/cncf-tag-app-delivery/topics)

--- a/website/content/ko/_index.md
+++ b/website/content/ko/_index.md
@@ -46,7 +46,7 @@ TAG는 운영 원칙(charter)에 따라 관련된 프로젝트를 지원한다.
 
 ### 추가 자료
 
-- [TAG 운영 원칙](https://github.com/cncf/toc/blob/main/tags/app-delivery.md)
+- [TAG 운영 원칙](https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.md)
 - 슬랙 채널: [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5)
     - [CNCF Slack 가입](https://slack.cncf.io/)
 - [이메일 목록](https://lists.cncf.io/g/cncf-tag-app-delivery/topics)

--- a/website/content/zh/_index.md
+++ b/website/content/zh/_index.md
@@ -44,7 +44,7 @@ list_pages: true
 
 ### 更多资源
 
-- [TAG 章程](https://github.com/cncf/toc/blob/main/tags/app-delivery.md)
+- [TAG 章程](https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.md)
 - Slack 频道： [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5)
     - [邀请你自己加入 CNCF Slack](https://slack.cncf.io/)
 - [邮件列表](https://lists.cncf.io/g/cncf-tag-app-delivery/topics)


### PR DESCRIPTION
The location of the TAG charter in the TOC repo has changed. This PR should update all links pointing to it.