### PR TITLE
Temporarily deactivate French page

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -86,12 +86,12 @@ weight = 5
 [languages.es.params]
 description = "El TAG App Delivery se centra en habilitar proyectos e iniciativas relacionados con el despliegue de aplicaciones cloud-native, incluyendo su construcción, manejo y operativa."
 
-[languages.fr]
-title = "CNCF TAG App Delivery"
-description = "Le TAG App Delivery se concentre sur la mise en oeuvre de projets et d'initiatives liés à la livraison d'applications cloud natives, comprenant leur création, déploiement, gestion et exploitation."
-languageName = "Français(French)"
-contentDir = "content/fr"
-weight = 6
+# [languages.fr]
+# title = "CNCF TAG App Delivery"
+# description = "Le TAG App Delivery se concentre sur la mise en oeuvre de projets et d'initiatives liés à la livraison d'applications cloud natives, comprenant leur création, déploiement, gestion et exploitation."
+# languageName = "Français(French)"
+# contentDir = "content/fr"
+# weight = 6
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
With the [new language support flow](https://github.com/cncf/tag-app-delivery/pull/612) we now require that each language not only is configured in `website/config.toml` but also has a corresponding folder in `website/content/`. Otherwise the page will remain empty.
To reduce confusion, I've disabled French in the config for now until the community has translated at least one key page so the script can do its thing and duplicate the other pages from English.
cc @abangser @mathieu-benoit 