### PR TITLE
Fixes whitepapers defaulting to Spanish

### DIFF
--- a/operator-whitepaper/latest/index.md
+++ b/operator-whitepaper/latest/index.md
@@ -4,7 +4,6 @@ pdf: https://github.com/cncf/tag-app-delivery/blob/main/operator-whitepaper/v1/C
 version_info: https://github.com/cncf/tag-app-delivery/blob/main/operator-whitepaper/latest/README.md
 description: "In this document, we outline not only the taxonomy of an operator but the recommended configuration, implementation and use cases for an operator application management system."
 type: whitepapers
-url: /whitepapers/operator
 ---
 
 ## Table of Contents

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -7,7 +7,6 @@ This document refers to, enhances, and follows similar standards as the followin
 [Cloud Maturity Model](https://maturitymodel.cncf.io/)<br/>
 [Platforms Definition White Paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/)"
 type: whitepapers
-url: /whitepapers/platform-eng-maturity-model
 ---
 
 

--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -4,7 +4,6 @@ pdf: https://github.com/cncf/tag-app-delivery/raw/main/platforms-whitepaper/v1/a
 version_info: https://github.com/cncf/tag-app-delivery/tree/main/platforms-whitepaper/README.md
 description: "This paper intends to support enterprise leaders, enterprise architects and platform team leaders to advocate for, investigate and plan internal platforms for cloud computing. We believe platforms significantly impact enterprises' actual value streams, but only indirectly, so leadership consensus and support is vital to the long-term sustainability and success of platform teams. In this paper we'll enable that support by discussing what the value of platforms is, how to measure it, and how to implement platform teams that maximize it."
 type: whitepapers
-url: /whitepapers/platforms
 ---
 
 ## Introduction


### PR DESCRIPTION
the `url` property in the frontmatter of the whitepapers somehow made it so that Spanish came up as the default page (we don't know why). With the property removed from the original whitepaper, all symlinked and copied files should be fine now. 