### PR TITLE
update TAG leads and TOC Liaisons

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,13 +10,10 @@
 #
 # Unless a later match takes precedence, these owners will be requested for
 # review when someone opens a pull request.
-*   @AloisReitbauer @thschue @joshgav @lianmakesthings @kgamanji @angellk
+*   @thschue @joshgav @lianmakesthings @kgamanji @angellk @linsun
 
 # Platforms WG
-/platforms-*/ @AloisReitbauer @thschue @joshgav @lianmakesthings @kgamanji  @angellk @abangser @roberthstrand @krumware
-
-# GitOps WG
-/gitops-*/ @AloisReitbauer @thschue @joshgav @lianmakesthings @kgamanji @angellk @todaywasawesome @chris-short @scottrigby
+/platforms-*/ @thschue @joshgav @lianmakesthings @kgamanji  @angellk @abangser @roberthstrand @krumware @linsun
 
 # Artifacts WG
-/artifacts-*/ @AloisReitbauer @thschue @joshgav @lianmakesthings @kgamanji @angellk @sabre1041 @rchincha
+/artifacts-*/ @thschue @joshgav @lianmakesthings @kgamanji @angellk @sabre1041 @rchincha @linsun

--- a/README.md
+++ b/README.md
@@ -31,16 +31,17 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 ## Leads
 
-- Alois Reitbauer (@AloisReitbauer) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
+- Lian Li (@lianmakesthings) (Co-Chair, Term: 2024/04/16 - 2026/04/15)
 - Josh Gavant (@joshgav) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
 - Thomas Schuetz (@thschue) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
-- Lian Li (@lianmakesthings) (TL)
 - Karena Angell (@angellk) (TL)
 
 ## TOC Liaisons
 - Katie Gamanji (@kgamanji)
+- Lin Sun (@linsun)
 
 ## Emeritus Leads
+- Alois Reitbauer (@AloisReitbauer)
 - Jennifer Strejevitch (@Jenninha)
 - Hongchao Deng (@hongchaodeng)
 - Alex Jones (@AlexsJones)

--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -43,12 +43,16 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 ## Leads
 
-- [Alois Reitbauer](https://github.com/AloisReitbauer) (Chair)
 - [Josh Gavant](https://github.com/joshgav) (Chair)
 - [Thomas Schuetz](https://github.com/thschue) (Chair)
-- [Alex Jones](https://github.com/alexsjones) (TL)
-- [Lian Li](https://github.com/lianmakesthings) (TL)
+- [Lian Li](https://github.com/lianmakesthings) (Chair)
 - [Karena Angell](https://github.com/angellk) (TL)
+
+### Emeritus Leads
+- [Alois Reitbauer](https://github.com/AloisReitbauer)
+- [Jennifer Strejevitch](https://github.com/Jenninha)
+- [Hongchao Deng](https://github.com/hongchaodeng)
+- [Alex Jones](https://github.com/AlexsJones)
 
 ### Additional Resources
 

--- a/website/content/ja/_index.md
+++ b/website/content/ja/_index.md
@@ -32,11 +32,9 @@ TAG Appデリバリーは、クラウドネイティブ・アプリケーショ�
 
 ## リーダー
 
-- [Alois Reitbauer](https://github.com/AloisReitbauer) (チェア)
 - [Josh Gavant](https://github.com/joshgav) (チェア)
 - [Thomas Schuetz](https://github.com/thschue) (チェア)
-- [Alex Jones](https://github.com/alexsjones) (テックリード)
-- [Lian Li](https://github.com/lianmakesthings) (テックリード)
+- [Lian Li](https://github.com/lianmakesthings) (チェア)
 - [Karena Angell](https://github.com/angellk) (テックリード)
 
 ### その他の資料

--- a/website/content/ko/_index.md
+++ b/website/content/ko/_index.md
@@ -37,11 +37,9 @@ TAG는 운영 원칙(charter)에 따라 관련된 프로젝트를 지원한다.
 
 ## 리드(leads)
 
-- [Alois Reitbauer](https://github.com/AloisReitbauer) (의장)
 - [Josh Gavant](https://github.com/joshgav) (의장)
 - [Thomas Schuetz](https://github.com/thschue) (의장)
-- [Alex Jones](https://github.com/alexsjones) (TL)
-- [Lian Li](https://github.com/lianmakesthings) (TL)
+- [Lian Li](https://github.com/lianmakesthings) (의장)
 - [Karena Angell](https://github.com/angellk) (TL)
 
 ### 추가 자료

--- a/website/content/zh/_index.md
+++ b/website/content/zh/_index.md
@@ -35,11 +35,9 @@ list_pages: true
 
 ## 领导者
 
-- [Alois Reitbauer](https://github.com/AloisReitbauer) （主席）
 - [Josh Gavant](https://github.com/joshgav) （主席）
 - [Thomas Schuetz](https://github.com/thschue) （主席）
-- [Alex Jones](https://github.com/alexsjones) (TL)
-- [Lian Li](https://github.com/lianmakesthings) (TL)
+- [Lian Li](https://github.com/lianmakesthings) (主席)
 - [Karena Angell](https://github.com/angellk) (TL)
 
 ### 更多资源


### PR DESCRIPTION
- Alois stepped down as Chair
- Lian was voted in and confirmed by TOC
- Add Lin Sun as TOC Liaison
- Add Alois as Emeritus Lead
- Changed CODEOWNERS (add linsun, remove Alois and remove GitOps WG)