### PR TITLE
Set fixed urls relative to language

### DIFF
--- a/operator-whitepaper/latest/index.md
+++ b/operator-whitepaper/latest/index.md
@@ -4,7 +4,7 @@ pdf: https://github.com/cncf/tag-app-delivery/blob/main/operator-whitepaper/v1/C
 version_info: https://github.com/cncf/tag-app-delivery/blob/main/operator-whitepaper/latest/README.md
 description: "In this document, we outline not only the taxonomy of an operator but the recommended configuration, implementation and use cases for an operator application management system."
 type: whitepapers
-url: /whitepapers/operator
+url: whitepapers/operator
 ---
 
 ## Table of Contents

--- a/operator-whitepaper/latest/index.md
+++ b/operator-whitepaper/latest/index.md
@@ -4,6 +4,7 @@ pdf: https://github.com/cncf/tag-app-delivery/blob/main/operator-whitepaper/v1/C
 version_info: https://github.com/cncf/tag-app-delivery/blob/main/operator-whitepaper/latest/README.md
 description: "In this document, we outline not only the taxonomy of an operator but the recommended configuration, implementation and use cases for an operator application management system."
 type: whitepapers
+url: /whitepapers/operator
 ---
 
 ## Table of Contents

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -7,7 +7,7 @@ This document refers to, enhances, and follows similar standards as the followin
 [Cloud Maturity Model](https://maturitymodel.cncf.io/)<br/>
 [Platforms Definition White Paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/)"
 type: whitepapers
-url: /whitepapers/platform-eng-maturity-model
+url: whitepapers/platform-eng-maturity-model
 ---
 
 

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -7,6 +7,7 @@ This document refers to, enhances, and follows similar standards as the followin
 [Cloud Maturity Model](https://maturitymodel.cncf.io/)<br/>
 [Platforms Definition White Paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/)"
 type: whitepapers
+url: /whitepapers/platform-eng-maturity-model
 ---
 
 

--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -4,6 +4,7 @@ pdf: https://github.com/cncf/tag-app-delivery/raw/main/platforms-whitepaper/v1/a
 version_info: https://github.com/cncf/tag-app-delivery/tree/main/platforms-whitepaper/README.md
 description: "This paper intends to support enterprise leaders, enterprise architects and platform team leaders to advocate for, investigate and plan internal platforms for cloud computing. We believe platforms significantly impact enterprises' actual value streams, but only indirectly, so leadership consensus and support is vital to the long-term sustainability and success of platform teams. In this paper we'll enable that support by discussing what the value of platforms is, how to measure it, and how to implement platform teams that maximize it."
 type: whitepapers
+url: /whitepapers/platforms
 ---
 
 ## Introduction

--- a/platforms-whitepaper/latest/index.md
+++ b/platforms-whitepaper/latest/index.md
@@ -4,7 +4,7 @@ pdf: https://github.com/cncf/tag-app-delivery/raw/main/platforms-whitepaper/v1/a
 version_info: https://github.com/cncf/tag-app-delivery/tree/main/platforms-whitepaper/README.md
 description: "This paper intends to support enterprise leaders, enterprise architects and platform team leaders to advocate for, investigate and plan internal platforms for cloud computing. We believe platforms significantly impact enterprises' actual value streams, but only indirectly, so leadership consensus and support is vital to the long-term sustainability and success of platform teams. In this paper we'll enable that support by discussing what the value of platforms is, how to measure it, and how to implement platform teams that maximize it."
 type: whitepapers
-url: /whitepapers/platforms
+url: whitepapers/platforms
 ---
 
 ## Introduction


### PR DESCRIPTION
Fixes https://github.com/cncf/tag-app-delivery/issues/626

Originally, we set [fixed URLs for the whitepapers](https://github.com/cncf/tag-app-delivery/pull/622). 
When these were duplicated due to the [new script for language support](https://github.com/cncf/tag-app-delivery/pull/612), they also copied the fix URL. That would lead to issues, like the default page [being hijacked by a non-default language](https://github.com/cncf/tag-app-delivery/issues/600).
By removing the fixed URL, we solved the language issue, but [broke backlinks to the whitepapers](https://github.com/cncf/tag-app-delivery/issues/626).

According to hugos docs, for multilingual support, fixed URLs need to be set [relative to the languagecode](https://gohugo.io/content-management/urls/).

This PR should bring back the fix URL, so it always points to the default language version (English) while the other languages will include their language code in the URL.
