### PR TITLE
Use shortcode to highlight important page info

### DIFF
--- a/website/content/en/wgs/operator/_index.md
+++ b/website/content/en/wgs/operator/_index.md
@@ -3,7 +3,9 @@ title: Operator Working Group
 list_pages: true
 inactive: true
 ---
-## This working group is currently inactive
+{{% alert color="warning" %}}
+  This working group is currently inactive
+{{% /alert %}}
 
 ### Current Goal 
 Create A Whitepaper (Initially Definition of an Operator)


### PR DESCRIPTION
Using the alert shortcode [provided by the template](https://www.docsy.dev/docs/adding-content/shortcodes/#shortcode-helpers) to highlight inactivity of the Operator WG