### PR TITLE
Add Alois to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,10 +10,10 @@
 #
 # Unless a later match takes precedence, these owners will be requested for
 # review when someone opens a pull request.
-*   @thschue @joshgav @lianmakesthings @kgamanji @angellk @linsun
+*   @thschue @joshgav @lianmakesthings @kgamanji @angellk @linsun @AloisReitbauer
 
 # Platforms WG
-/platforms-*/ @thschue @joshgav @lianmakesthings @kgamanji  @angellk @abangser @roberthstrand @krumware @linsun
+/platforms-*/ @thschue @joshgav @lianmakesthings @kgamanji  @angellk @abangser @roberthstrand @krumware @linsun @AloisReitbauer
 
 # Artifacts WG
-/artifacts-*/ @thschue @joshgav @lianmakesthings @kgamanji @angellk @sabre1041 @rchincha @linsun
+/artifacts-*/ @thschue @joshgav @lianmakesthings @kgamanji @angellk @sabre1041 @rchincha @linsun @AloisReitbauer


### PR DESCRIPTION
Alois stepped down as chair, but we want to keep him on as TL.

closes #629 