### PR TITLE
Fix Some Technical Errors in the Platform Engineering Maturity Model

### DIFF
--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -374,7 +374,7 @@ Platforms and capabilities are centrally documented and discoverable, and proces
 * A central team provides a register of available shared services across the organization.
 * Loose standards, such as requiring an automatable API and usage docs, are applied to capabilities.
 * Infrastructure as Code is used to allow easier traceability of deployed services.
-* Audits for compliance regulations such as PCI DSS or HIPPA are enabled through the service inventories.
+* Audits for compliance regulations such as PCI DSS or HIPAA are enabled through the service inventories.
 * Migration and upgrade work is tracked against a burndown chart enabling the organization to track rate of compliance and time until completion.
 * Tracking does not indicate level of support; often upgrades at this stage are still manual and bespoke.
 

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -465,7 +465,7 @@ Dedicated teams or tools are employed to gather and review feedback and summariz
 
 * Before delivering any new platform feature, the team discusses how to evaluate the outcome from their work.
 * The organization has broad alignment on measures that indicate success of platform initiatives.
-* A [product manager]({{< ref "/wgs/platforms/glossary#platform-product-managers" >}}) or dedicated team member drives an ongoing and consistent feedback collection and analysis process.
+* A [product manager]({{< ref "/wgs/platforms/glossary#platform-team" >}}) or dedicated team member drives an ongoing and consistent feedback collection and analysis process.
 * The organization has established metrics and goals to observe and target to indicate success.
 
 #### Example Scenarios:

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -319,7 +319,7 @@ Solutions are offered in a way that provides autonomy to users and requires litt
 
 * An API is provided which abstracts the creation and maintenance of databases and provides users with any information they require to leverage that platform capability such as a connection string, location for secret data, and dashboard with observability data.
 
-### Level 4, Optimizing — Managed services
+### Level 4, Optimizing — Integrated services
 
 Platform capabilities are transparently integrated into the tools and processes that teams already use to do their work. Some capabilities are provisioned automatically, such as observability or identity management for a deployed service. When users hit the edges of the provided services, there is an opportunity to move past automated solutions and customize for their needs without leaving the internal offerings because platform capabilities are considered building blocks. These building blocks are used to build transparent and automatic compositions to meet the higher-level use cases while enabling deeper customization where necessary.
 

--- a/platforms-maturity-model/v1/index.md
+++ b/platforms-maturity-model/v1/index.md
@@ -31,7 +31,7 @@ window.onhashchange = function() {
 
 ## Introduction
 
-CNCF's initial [Platforms Definition white paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/) describes what internal platforms for cloud computing are and the values they promise to deliver to enterprises. But to achieve those values an organization must reflect and deliberately pursue outcomes and practices that are impactful for them, keeping in mind that every organization relies on an internal platform crafted for its own organization - even if that platform is just documentation on how to use third party services. This maturity model provides a framework for that reflection and for identifying opportunities for improvement in any organization.
+CNCF's initial [Platforms White Paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/) describes what internal platforms for cloud computing are and the values they promise to deliver to enterprises. But to achieve those values an organization must reflect and deliberately pursue outcomes and practices that are impactful for them, keeping in mind that every organization relies on an internal platform crafted for its own organization - even if that platform is just documentation on how to use third party services. This maturity model provides a framework for that reflection and for identifying opportunities for improvement in any organization.
 
 ## What is platform engineering?
 
@@ -39,7 +39,7 @@ Inspired by the cross-functional cooperation promised by DevOps, platforms and p
 
 [**Platform engineering**]({{< ref "/wgs/platforms/glossary#platform-engineering" >}}) is the practice of planning and providing such computing platforms to developers and users and encompasses all parts of platforms and their capabilities — their people, processes, policies and technologies; as well as the desired business outcomes that drive them.
 
-Please read the [CNCF Platforms Definition white paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/) first for complete context.
+Please read the [CNCF Platforms White Paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/) first for complete context.
 
 ## How to use this model
 

--- a/website/content/zh/wgs/platforms/maturity-model/v1/index.md
+++ b/website/content/zh/wgs/platforms/maturity-model/v1/index.md
@@ -103,7 +103,6 @@ CNCF 的首份[平台定义白皮书](https://tag-app-delivery.cncf.io/whitepape
 
 <div style="min-width:620px">
 {{< tabs tabTotal="6">}}
-
 {{< tab tabName="Investment" >}}
 
 <h4 style="color:gray;padding-bottom:10px;padding-top:20px"><i>How are staff and funds allocated to platform capabilities?</i></h4>

--- a/website/content/zh/wgs/platforms/maturity-model/v1/index.md
+++ b/website/content/zh/wgs/platforms/maturity-model/v1/index.md
@@ -28,6 +28,8 @@ window.onhashchange = function() {
 }
 </script>
 
+{{< translation-note >}}
+
 ## 概述
 
 CNCF 的首份[平台定义白皮书](https://tag-app-delivery.cncf.io/whitepapers/platforms/) 描述了什么是云计算下的内部平台，以及该平台应为企业带来哪些价值。但要实现这些价值，一个组织必须反思并刻意追求对它们有影响的成果和实践，同时记住每个组织都依赖于为其自身组织量身定制的内部平台 - 即使这个平台只是关于如何使用第三方服务的文档。这个成熟度模型提供了一个框架，用于反思和识别任何组织中改进的机会。
@@ -101,6 +103,7 @@ CNCF 的首份[平台定义白皮书](https://tag-app-delivery.cncf.io/whitepape
 
 <div style="min-width:620px">
 {{< tabs tabTotal="6">}}
+
 {{< tab tabName="Investment" >}}
 
 <h4 style="color:gray;padding-bottom:10px;padding-top:20px"><i>How are staff and funds allocated to platform capabilities?</i></h4>

--- a/website/layouts/shortcodes/translation-note.html
+++ b/website/layouts/shortcodes/translation-note.html
@@ -1,0 +1,6 @@
+<div style="border-left: 4px solid #000000; padding: 10px; background-color: #F4F4F4; margin: 10px 0;">
+    <strong>Note:</strong>
+    The content on this page may be outdated. </br>
+    </br>
+    This page has been updated behind the English version, so the content may be outdated. For the latest information, please refer to the English version of the page.
+</div>


### PR DESCRIPTION
This PR fixes some minor technical errors in the Platform Engineering Maturity Model that I found while working on the paper's Japanese translation.

### Fixes
#### The title of the Platforms White Paper
- The maturity model includes sentences referring to the White Paper, but its title is stated as "Platform Definitions White Paper."
- I fixed it to the correct title.

#### typo
- HIPPA -> HIPAA

#### A section title in the model detail
- In the model detail, the section title of `Interface` - `Level 4` is "Managed services," but in the modal table, it's "Integrated services."
- I changed the section title from "Managed services" to "Integrated services" because it seems the section's content focuses on integration around platform capabilities.

#### A link pointing to a section of the Glossary
- Now, the glossary doesn't have the section named "Platform Product Manager." The product manager is explained only in a section titled "Platform Team."
- I changed the "Product Manager" link to target the "Product Team."

### Other Changes
I've added a note explaining that the translation has not been updated from the English version to the translated one. In this case, it's only the `zh` version. I created the note as a hugo shortcode so it can be reused on other pages if needed.
- [The example of the note on preview page](https://deploy-preview-660--tag-app-delivery.netlify.app/zh/wgs/platforms/maturity-model/v1/)