### PR TITLE
chore: update i18n diff action

### DIFF
--- a/.github/workflows/notice-i18n-tasks.yml
+++ b/.github/workflows/notice-i18n-tasks.yml
@@ -17,6 +17,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
+        fetch-depth: 1
+    
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0


### PR DESCRIPTION
Fixes #661 
If we checkout main and our PR's fork/branch then we should be able to do a diff against them. Moved fetch-depth to main to 1 because we don't need to pull "all the things"! 