### PR TITLE
chore: Update Youtube Link to Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 * Zoom Meeting: <https://zoom.us/j/7276783015>
     * Passcode: 77777
 * Recordings of previous meetings:
-    * <https://www.youtube.com/@cncf-tag-app-delivery/videos>
+    * <https://www.youtube.com/playlist?list=PLjNzvzqUSpxJ0JfD6vrdF5bsuBaJQ2BRT>
     * Prior to April 2021: <https://www.youtube.com/playlist?list=PLj6h78yzYM2OHd1Ht3jiZuucWzvouAAci>
 
 ## Leads

--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -39,7 +39,7 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 * [Agenda and Notes](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
 * [Zoom Meeting](https://zoom.us/j/7276783015) (Passcode: 77777)
-* [Recordings of previous meetings](https://www.youtube.com/@cncf-tag-app-delivery)
+* [Recordings of previous meetings](https://www.youtube.com/playlist?list=PLjNzvzqUSpxJ0JfD6vrdF5bsuBaJQ2BRT)
 
 ## Leads
 

--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -39,7 +39,7 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 
 * [Agenda and Notes](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
 * [Zoom Meeting](https://zoom.us/j/7276783015) (Passcode: 77777)
-* [Recordings of previous meetings](https://www.youtube.com/playlist?list=PLj6h78yzYM2OHd1Ht3jiZuucWzvouAAci)
+* [Recordings of previous meetings](https://www.youtube.com/@cncf-tag-app-delivery)
 
 ## Leads
 

--- a/website/content/ja/_index.md
+++ b/website/content/ja/_index.md
@@ -28,7 +28,7 @@ TAG Appデリバリーは、クラウドネイティブ・アプリケーショ�
 
 * [アジェンダと議事録](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
 * [Zoomミーティング](https://zoom.us/j/7276783015) (パスコード: 77777)
-* [過去のミーティングの録画](https://www.youtube.com/@cncf-tag-app-delivery)
+* [過去のミーティングの録画](https://www.youtube.com/playlist?list=PLjNzvzqUSpxJ0JfD6vrdF5bsuBaJQ2BRT)
 
 ## リーダー
 

--- a/website/content/ja/_index.md
+++ b/website/content/ja/_index.md
@@ -28,7 +28,7 @@ TAG Appデリバリーは、クラウドネイティブ・アプリケーショ�
 
 * [アジェンダと議事録](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
 * [Zoomミーティング](https://zoom.us/j/7276783015) (パスコード: 77777)
-* [過去のミーティングの録画](https://www.youtube.com/playlist?list=PLj6h78yzYM2OHd1Ht3jiZuucWzvouAAci)
+* [過去のミーティングの録画](https://www.youtube.com/@cncf-tag-app-delivery)
 
 ## リーダー
 

--- a/website/content/ko/_index.md
+++ b/website/content/ko/_index.md
@@ -33,7 +33,7 @@ TAG는 운영 원칙(charter)에 따라 관련된 프로젝트를 지원한다.
 
 * [아젠다 및 메모](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
 * [줌 회의](https://zoom.us/j/7276783015) (Passcode: 77777)
-* [이전 회의 영상](https://www.youtube.com/@cncf-tag-app-delivery)
+* [이전 회의 영상](https://www.youtube.com/playlist?list=PLjNzvzqUSpxJ0JfD6vrdF5bsuBaJQ2BRT)
 
 ## 리드(leads)
 

--- a/website/content/ko/_index.md
+++ b/website/content/ko/_index.md
@@ -33,7 +33,7 @@ TAG는 운영 원칙(charter)에 따라 관련된 프로젝트를 지원한다.
 
 * [아젠다 및 메모](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
 * [줌 회의](https://zoom.us/j/7276783015) (Passcode: 77777)
-* [이전 회의 영상](https://www.youtube.com/playlist?list=PLj6h78yzYM2OHd1Ht3jiZuucWzvouAAci)
+* [이전 회의 영상](https://www.youtube.com/@cncf-tag-app-delivery)
 
 ## 리드(leads)
 

--- a/website/content/zh/_index.md
+++ b/website/content/zh/_index.md
@@ -31,7 +31,7 @@ list_pages: true
 
 * [议程和说明](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
 * [Zoom 会议](https://zoom.us/j/7276783015) (密码：77777)
-* [历史会议纪要](https://www.youtube.com/@cncf-tag-app-delivery)
+* [历史会议纪要](https://www.youtube.com/playlist?list=PLjNzvzqUSpxJ0JfD6vrdF5bsuBaJQ2BRT)
 
 ## 领导者
 

--- a/website/content/zh/_index.md
+++ b/website/content/zh/_index.md
@@ -31,7 +31,7 @@ list_pages: true
 
 * [议程和说明](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
 * [Zoom 会议](https://zoom.us/j/7276783015) (密码：77777)
-* [历史会议纪要](https://www.youtube.com/playlist?list=PLj6h78yzYM2OHd1Ht3jiZuucWzvouAAci)
+* [历史会议纪要](https://www.youtube.com/@cncf-tag-app-delivery)
 
 ## 领导者
 


### PR DESCRIPTION
Youtube Link was taking to the playlist which only has pre-April 2021 recordings. Updated the link to reflect the channel!