### PR TITLE
doc: update leadership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,13 +10,13 @@
 #
 # Unless a later match takes precedence, these owners will be requested for
 # review when someone opens a pull request.
-*   @thschue @joshgav @lianmakesthings @kgamanji @angellk @linsun @AloisReitbauer @roberthstrand
+*   @thschue @lianmakesthings @kgamanji @linsun @AloisReitbauer @roberthstrand
 
 # Platforms WG
-/platforms-*/ @thschue @joshgav @lianmakesthings @kgamanji  @angellk @abangser @roberthstrand @krumware @linsun @AloisReitbauer
+/platforms-*/ @thschue @lianmakesthings @kgamanji @abangser @roberthstrand @krumware @linsun @AloisReitbauer
 
 # Artifacts WG
-/artifacts-*/ @thschue @joshgav @lianmakesthings @kgamanji @angellk @sabre1041 @rchincha @linsun @AloisReitbauer @roberthstrand
+/artifacts-*/ @thschue @lianmakesthings @kgamanji @sabre1041 @rchincha @linsun @AloisReitbauer @roberthstrand
 
 # App Development WG
-/app-development-*/ @thschue @joshgav @lianmakesthings @kgamanji @angellk @linsun @AloisReitbauer @roberthstrand @salaboy @danieloh30 @ThomasVitale
+/app-development-*/ @thschue @lianmakesthings @kgamanji @linsun @AloisReitbauer @roberthstrand @salaboy @danieloh30 @ThomasVitale

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 - Lian Li (@lianmakesthings) (Co-Chair, Term: 2024/04/16 - 2026/04/15)
 - Josh Gavant (@joshgav) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
 - Thomas Schuetz (@thschue) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
-- Karena Angell (@angellk) (TL)
 - Roberth Strand (@roberthstrand) (TL)
 
 ## TOC Liaisons
@@ -46,6 +45,8 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 - Jennifer Strejevitch (@Jenninha)
 - Hongchao Deng (@hongchaodeng)
 - Alex Jones (@AlexsJones)
+- Josh Gavant (@joshgav)
+- Karena Angell (@angellk)
 
 ## Working Groups
 


### PR DESCRIPTION
## This PR
* Removes @angellk and @joshgav from CODEOWNERS and add them as emeritus

Thank you to the outgoing members for supporting the TAG!