### PR TITLE
Add Labeler GitHub Actions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,55 @@
+governance:
+  - changed-files:
+      - any-glob-to-any-file:
+          - governance/*
+
+wg-appdev:
+  - changed-files:
+      - any-glob-to-any-file:
+          - app-development-wg/*
+
+wg-gitops:
+  - changed-files:
+      - any-glob-to-any-file:
+          - gitops-wg/*
+
+wg-infra-lifecycle:
+  - changed-files:
+      - any-glob-to-any-file:
+          - infra-lifecycle-wg/*
+
+wg-platforms:
+  - changed-files:
+      - any-glob-to-any-file:
+          - platforms-wg/*
+
+website:
+  - changed-files:
+      - any-glob-to-any-file:
+          - website/*
+
+# Language-specific labels
+language/en:
+  - changed-files:
+      - any-glob-to-any-file:
+          - website/content/en/*
+
+language/es:
+  - changed-files:
+      - any-glob-to-any-file:
+          - website/content/es/*
+
+language/ja:
+  - changed-files:
+      - any-glob-to-any-file:
+          - website/content/ja/*
+
+language/ko:
+  - changed-files:
+      - any-glob-to-any-file:
+          - website/content/ko/*
+
+language/zh:
+  - changed-files:
+      - any-glob-to-any-file:
+          - website/content/zh/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: labeler
+
+on: pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
## Feature Description

- Add [actions/labeler](https://github.com/actions/labeler) workflow.

This workflow automatically labels PRs based on the files that were changed. Since this repository has directories for each WG and project, it appears to work well.