### PR TITLE
[Chore] add content from readme that is missing in website (signed)

### DIFF
--- a/website/content/en/wgs/platforms/_index.md
+++ b/website/content/en/wgs/platforms/_index.md
@@ -9,6 +9,8 @@ To participate join us on Slack at
 [#wg-platforms](https://cloud-native.slack.com/archives/C020RHD43BP)
 or the meetings described below.
 
+To register for updates and to "Join" the group, please also consider joining the [TAG App Delivery CNCF Community Group](https://community.cncf.io/tag-app-delivery/)
+
 ## Chairs
 
 * Josh Gavant (@joshgav)
@@ -19,9 +21,9 @@ or the meetings described below.
 ## Meetings
 
 * Meeting schedule: 2nd and 4th Tuesday of each month at [1600 Europe/London time](https://www.timeanddate.com/worldclock/converter.html?iso=20240514T150000&p1=136)
-    * [2nd Tuesday event](https://www.google.com/calendar/event?eid=cWE0ZHMyMThicDF1dDZsa3N2ZGlqYmt2Z2pfMjAyNDA1MTRUMTUwMDAwWiBsaW51eGZvdW5kYXRpb24ub3JnX281YXZqbHZ0MmNhZTlicTdhOTVlbWM0NzQwQGc&ctz=UTC)
-    * [4th Tuesday event](https://www.google.com/calendar/event?eid=NGhyOHY1ZWVrbDliODY3bXU5ZnRtYWo0ZGdfMjAyNDA1MjhUMTYwMDAwWiBsaW51eGZvdW5kYXRpb24ub3JnX281YXZqbHZ0MmNhZTlicTdhOTVlbWM0NzQwQGc&ctz=UTC)
-    * [Full CNCF calendar](https://calendar.google.com/calendar/u/0/embed?src=linuxfoundation.org_o5avjlvt2cae9bq7a95emc4740@group.calendar.google.com)
+* Please RSVP for meetings on the [TAG App Delivery Community Groups Page](https://community.cncf.io/tag-app-delivery/). This will also provide a calendar entry.
+* Meeting Location, Zoom: https://zoom.us/j/7276783015?pwd=R0RJMkRzQ1ZjcmE0WERGcTJTOEVyUT09
 * Zoom: https://zoom.us/j/7276783015?pwd=R0RJMkRzQ1ZjcmE0WERGcTJTOEVyUT09
     * Passcode: 77777
 * Agendas and notes: <https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg>
+* Previous meetings can be viewed on the [TAG YouTube Channel](https://www.youtube.com/watch?v=eZYSQnsWRco&list=PLjNzvzqUSpxKH8X7wNfYZtkH_ARSeeQH0)


### PR DESCRIPTION
This content was added to the platforms-wg readme in https://github.com/cncf/tag-app-delivery/pull/684, but was not also added to the website content.
This brings the two to parity.

(recreates #707)