### PR TITLE
Enable i18n with pt-br(Portuguese) for website

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -93,6 +93,14 @@ description = "El TAG App Delivery se centra en habilitar proyectos e iniciativa
 # contentDir = "content/fr"
 # weight = 6
 
+[languages.pt-br]
+title = "CNCF TAG App Delivery"
+languageName = "Português(Portuguese)"
+contentDir = "content/pt-br"
+weight = 7
+[languages.pt-br.params]
+description = "O TAG App Delivery foca em permitir projetos e iniciativas relacionados à entrega de aplicações nativas da nuvem, incluindo sua construção, implantação, gerenciamento e operação."
+
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]

--- a/website/content/pt-br/_index.md
+++ b/website/content/pt-br/_index.md
@@ -1,0 +1,59 @@
+---
+title: "CNCF TAG App Delivery"
+list_pages: true
+---
+
+<div class="row mt-5 mb-3">
+  <div class="col-lg-6">
+    <img src="/images/tag-app-delivery-horizontal-color.svg" alt="Logotipo do TAG App Delivery" style="max-width: 300px;">
+  </div>
+  <div class="col-lg-6">
+    <div class="lead">
+      Projetos e iniciativas relacionados à entrega de aplicações nativas da nuvem, incluindo construção, empacotamento, implantação, gerenciamento e operação.
+    </div>
+  </div>
+</div>
+
+O TAG coleta feedback de desenvolvedores de aplicações nativas da nuvem, engenheiros de plataforma e usuários finais; compartilha esse feedback com projetos em seu domínio; e produz orientações e exemplos para usuários finais.
+
+O TAG apoia projetos relacionados ao seu estatuto, 
+como aqueles no [Mapa da CNCF](https://landscape.cncf.io/card-mode) sob 
+[definição de aplicação e construção de imagem](https://landscape.cncf.io/card-mode?category=application-definition-image-build&project=hosted),
+[integração e entrega contínuas](https://landscape.cncf.io/card-mode?category=continuous-integration-delivery&project=hosted)
+e [registro de containers](https://landscape.cncf.io/card-mode?category=container-registry&project=hosted).
+
+Atualmente, existem dois grupos ativos sob o TAG - [WG Plataformas](./wgs/pt-br/platforms/) e [WG Artefatos](./wgs/pt-br/artifacts/).
+
+## Reuniões
+
+A cada duas semanas, às quartas-feiras às 11h00 AM ET ([converta para o seu horário local](https://dateful.com/convert/eastern-time-et?t=11)).
+
+As reuniões estão listadas no [calendário principal da CNCF](https://www.cncf.io/calendar/) assim como no [Calendário da Comunidade CNCF](https://community.cncf.io/tag-app-delivery/).
+
+* [Agenda e Notas](https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit#)
+* [Reunião no Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/98590236563?password=b0335b64-4162-4499-bb61-ff2c7dec2724)
+* [Gravações de reuniões anteriores](https://www.youtube.com/playlist?list=PLjNzvzqUSpxJ0JfD6vrdF5bsuBaJQ2BRT)
+
+## Líderes
+
+- [Josh Gavant](https://github.com/joshgav) (Chair)
+- [Thomas Schuetz](https://github.com/thschue) (Chair)
+- [Lian Li](https://github.com/lianmakesthings) (Chair)
+- [Karena Angell](https://github.com/angellk) (TL)
+- [Roberth Strand](https://github.com/roberthstrand) (TL)
+
+### Líderes Eméritas
+
+- [Alois Reitbauer](https://github.com/AloisReitbauer)
+- [Jennifer Strejevitch](https://github.com/Jenninha)
+- [Hongchao Deng](https://github.com/hongchaodeng)
+- [Alex Jones](https://github.com/AlexsJones)
+
+### Recursos Adicionais
+
+- [Estatuto do TAG](https://github.com/cncf/toc/blob/main/tags/tag-charters/app-delivery.md)
+- Canal do Slack: [#tag-app-delivery](https://cloud-native.slack.com/messages/CL3SL0CP5)
+  - [Convide-se para o Slack da CNCF](https://slack.cncf.io/)
+- Lista de e-mails (mailing list): https://lists.cncf.io/g/cncf-tag-app-delivery/topics
+
+<p class="mt-5"><img src="/images/man-using-laptop.jpg" alt="Homem trabalhando no computador"></p>

--- a/website/content/pt-br/blog/_index.md
+++ b/website/content/pt-br/blog/_index.md
@@ -1,0 +1,6 @@
+---
+title: Blog
+menu:
+  main:
+    weight: 40
+---

--- a/website/content/pt-br/contribute/_index.md
+++ b/website/content/pt-br/contribute/_index.md
@@ -11,7 +11,7 @@ Aqui estão algumas maneiras de começar a se envolver com o CNCF Technical Advi
 
 **Explore os tópicos que mais te interessam.**
 
-O TAG abrange diversos temas relacionados à Entrega de Aplicações. Alguns desses temas maiores se tornaram Grupos de Trabalho (Working Groups/WGs), mas ainda há muito a discutir no nível do TAG. Os títulos dos WGs e projetos podem parecer claros, mas às vezes não são. Continue lendo para descobrir como encontrar o projeto certo para você.
+O TAG abrange diversos temas relacionados à Entrega de Aplicações. Alguns desses temas maiores se tornaram Grupos de Trabalho (Working Groups/WGs), mas ainda há muito a discutir no nível do TAG. Os títulos dos WGs e projetos podem parecer claros, mas às vezes não são.
 
 **Participe do Slack**
 

--- a/website/content/pt-br/contribute/_index.md
+++ b/website/content/pt-br/contribute/_index.md
@@ -1,0 +1,38 @@
+---
+title: Contribua
+list_pages: false
+menu:
+  main:
+    weight: 20
+description: Formas de se envolver com o TAG
+---
+
+Aqui estão algumas maneiras de começar a se envolver com o CNCF Technical Advisory Group (TAG) App Delivery. Embora seja útil seguir essas etapas na ordem sugerida, você pode escolher o que faz mais sentido para você e começar por lá!
+
+**Explore os tópicos que mais te interessam.**
+
+O TAG abrange diversos temas relacionados à Entrega de Aplicações. Alguns desses temas maiores se tornaram Grupos de Trabalho (Working Groups/WGs), mas ainda há muito a discutir no nível do TAG. Os títulos dos WGs e projetos podem parecer claros, mas às vezes não são. Continue lendo para descobrir como encontrar o projeto certo para você.
+
+**Participe do Slack**
+
+O Slack da CNCF é bastante ativo e oferece muitos recursos valiosos. Uma boa maneira de começar é se apresentar em um canal do WG e compartilhar seu interesse. Os líderes do WG e outros membros poderão te orientar e ajudar você a se integrar.
+
+**Verifique os problemas (issues) no GitHub**
+
+Existem vários tipos de problemas disponíveis, desde questões de código até problemas de documentação e muito mais. Sinta-se à vontade para deixar um comentário ou uma sugestão. Você pode encontrar esses problemas na seção correspondente da organização GitHub da CNCF para cada TAG. Por exemplo, aqui está o link para o TAG de Entrega de Aplicações (App Delivery): https://github.com/cncf/tag-app-delivery
+
+**Revise os projetos em andamento que estão buscando contribuintes**
+
+Às vezes, não há problemas formais abertos, ou um problema anterior ainda pode precisar de contribuições contínuas. Nesses casos, a seção `Projetos` pode fornecer informações sobre como você pode se envolver em uma iniciativa em andamento.
+
+**Participe de uma reunião**
+
+Isso pode parecer intimidante no início, especialmente se você é novo, mas é uma excelente oportunidade para se integrar e conhecer pessoas depois de interagir no Slack. As reuniões são estruturadas com pontos de discussão em um documento compartilhado do Google. Você pode se apresentar (se quiser!) e também pode trazer um tópico para discussão.
+
+**Apresente uma nova idéia**
+
+Embora existam vários tópicos em andamento no TAG, todos começaram como novas idéias. Se você tem uma proposta nova, recomendamos que você [abra um problema usando o template `community contribution`](https://github.com/cncf/tag-app-delivery/issues/new) e comece a construir uma comunidade de pessoas interessadas em colaborar com você nisso!
+
+**Em resumo, comece do seu jeito**
+
+Os membros do TAG e dos WGs têm diferentes estilos de participação. Alguns nunca participaram de uma chamada, outros raramente interagem no GitHub. O verdadeiro valor da comunidade está na diversidade de experiências e idéias, que juntas ajudam a gerar conteúdo valioso para a comunidade cloud native. Sua participação e suas experiências são fundamentais para isso, então venha se juntar a nós hoje!

--- a/website/content/pt-br/search.md
+++ b/website/content/pt-br/search.md
@@ -1,0 +1,5 @@
+---
+title: Resultados da Pesquisa
+layout: search
+toc_hide: true
+---

--- a/website/content/pt-br/wgs/_index.md
+++ b/website/content/pt-br/wgs/_index.md
@@ -1,0 +1,8 @@
+---
+title: Grupos de Trabalho
+list_pages: true
+menu:
+  main:
+    weight: 30
+description: "O TAG estabelece grupos de trabalho (Working Groups/WGs) para realizar projetos e iniciativas específicos."
+---

--- a/website/content/pt-br/wgs/app-development/_index.md
+++ b/website/content/pt-br/wgs/app-development/_index.md
@@ -1,0 +1,24 @@
+---
+title: Grupo de Trabalho (WG) de Desenvolvimento de Aplicações
+list_pages: false
+---
+
+O [estatuto](./charter) descreve a missão e as táticas do grupo de trabalho (WG) de Desenvolvimento de Aplicações. Para participar, junte-se a nós no Slack em
+[#wg-app-development](https://cloud-native.slack.com/archives/C06SKDAQDEX)
+ou nas reuniões descritas abaixo.
+
+## Coordenadores
+
+* Mauricio Salatino | [GitHub](https://github.com/salaboy) | [Twitter](https://twitter.com/salaboy)
+* Daniel Oh | [GitHub](https://github.com/danieloh30) | [Twitter](https://twitter.com/danieloh30)
+* Thomas Vitale | [GitHub](https://github.com/ThomasVitale) | [Twitter](https://twitter.com/vitalethomas)
+
+## Reuniões
+
+* Agenda das reuniões: 1ª e 3ª quartas-feiras de cada mês às [16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20221213T160000&p1=1440)
+   
+* Agendas e notas: <[https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg](https://docs.google.com/document/d/17IOnJLGIGproKP93m_8Z5-WsZdq5s_UPRA2qQbGG9ks/edit?pli=1#heading=h.wtws91k8c1bo)>
+
+## Recursos
+
+* Problemas no GitHub: https://github.com/cncf/tag-app-delivery/issues?q=is%3Aissue+is%3Aopen+label%3Awg-app-development

--- a/website/content/pt-br/wgs/artifacts/_index.md
+++ b/website/content/pt-br/wgs/artifacts/_index.md
@@ -1,0 +1,5 @@
+---
+title: Grupo de Trabalho (WG) de Artefatos
+list_pages: false
+---
+{{< include path="assets/content/artifacts-wg/README.md" >}}

--- a/website/i18n/pt-br.toml
+++ b/website/i18n/pt-br.toml
@@ -1,0 +1,30 @@
+# UI strings. Buttons and similar.
+
+# Footer text
+[footer_all_rights_reserved]
+other = " | Documentação distribuída sob CC-BY-4.0"
+
+[post_create_issue]
+other = "Criar issue"
+
+# TOC
+[page_contents]
+other = "Conteúdo da Página"
+
+# Phrases for tags
+[ui_see_all_tags]
+other = "Ver todas as tags"
+[ui_tag]
+other = "Tag"
+[ui_tags]
+other = "Tags"
+[ui_search_by_tags]
+other = "Navegar por tags"
+[ui_tags_intro]
+other = "Use os filtros para navegar pelos posts do blog por tag."
+[ui_or_search_by_tags]
+other = "...ou navegue por tag"
+[ui_select_all]
+other = "Selecionar tudo"
+[ui_deselect_all]
+other = "Deselecionar tudo"


### PR DESCRIPTION
This PR makes Portuguese available in the language selection menu.

Translated Pages for Review:
- `website/config.toml`
- `website/i18n/pt-br.toml`

Additional Translations (as per #612):
- `website/content/pt-br/contribute/_index.md`
- `website/content/pt-br/search.md`
- `website/content/pt-br/wgs/_index.md`
- `website/content/pt-br/wgs/app-development/_index.md`
- `website/content/pt-br/wgs/artifacts/_index.md`



This is the first step to complete https://github.com/cncf/tag-app-delivery/issues/736