### PR TITLE
Chore: Update meeting link for wg-platforms to lfx

### DIFF
--- a/platforms-wg/README.md
+++ b/platforms-wg/README.md
@@ -21,8 +21,8 @@ To register for updates and to "Join" the group, please also consider joining th
 
 * Meeting schedule: 2nd and 4th Tuesday of each month at [1600 Europe/London time](https://www.timeanddate.com/worldclock/converter.html?iso=20240514T150000&p1=136)
 * Please RSVP for meetings on the [TAG App Delivery Community Groups Page](https://community.cncf.io/tag-app-delivery/). This will also provide a calendar entry.
-* Meeting Location, Zoom: https://zoom-lfx.platform.linuxfoundation.org/meeting/94326372364?password=0681764d-b152-4295-8bd2-6b9fcf77bff1
-    * Passcode: 77777
+* Meeting Location, Virtual: <https://zoom-lfx.platform.linuxfoundation.org/meeting/95319413756?password=a945340e-f322-437f-9653-cbf3f05ada69>
+  * Passcode: 77777
 * Agendas and notes: <https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg>
 * Previous meetings can be viewed on the [TAG YouTube Channel](https://www.youtube.com/watch?v=eZYSQnsWRco&list=PLjNzvzqUSpxKH8X7wNfYZtkH_ARSeeQH0)
 

--- a/website/content/en/wgs/platforms/_index.md
+++ b/website/content/en/wgs/platforms/_index.md
@@ -25,7 +25,7 @@ To register for updates and to "Join" the group, please also consider joining th
 
 * Meeting schedule: 2nd and 4th Tuesday of each month at [1600 Europe/London time](https://www.timeanddate.com/worldclock/converter.html?iso=20240514T150000&p1=136)
 * Please RSVP for meetings on the [TAG App Delivery Community Groups Page](https://community.cncf.io/tag-app-delivery/). This will also provide a calendar entry.
-* Meeting Location, Zoom: https://zoom-lfx.platform.linuxfoundation.org/meeting/94326372364?password=0681764d-b152-4295-8bd2-6b9fcf77bff1
-    * Passcode: 77777
+* Meeting Location, Virtual: <https://zoom-lfx.platform.linuxfoundation.org/meeting/95319413756?password=a945340e-f322-437f-9653-cbf3f05ada69>
+  * Passcode: 77777
 * Agendas and notes: <https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg>
 * Previous meetings can be viewed on the [TAG YouTube Channel](https://www.youtube.com/watch?v=eZYSQnsWRco&list=PLjNzvzqUSpxKH8X7wNfYZtkH_ARSeeQH0)

--- a/website/content/ja/wgs/platforms/_index.md
+++ b/website/content/ja/wgs/platforms/_index.md
@@ -25,7 +25,7 @@ To register for updates and to "Join" the group, please also consider joining th
 
 * Meeting schedule: 2nd and 4th Tuesday of each month at [1600 Europe/London time](https://www.timeanddate.com/worldclock/converter.html?iso=20240514T150000&p1=136)
 * Please RSVP for meetings on the [TAG App Delivery Community Groups Page](https://community.cncf.io/tag-app-delivery/). This will also provide a calendar entry.
-* Meeting Location, Zoom: https://zoom-lfx.platform.linuxfoundation.org/meeting/94326372364?password=0681764d-b152-4295-8bd2-6b9fcf77bff1
-    * Passcode: 77777
+* Meeting Location, Virtual: <https://zoom-lfx.platform.linuxfoundation.org/meeting/95319413756?password=a945340e-f322-437f-9653-cbf3f05ada69>
+  * Passcode: 77777
 * Agendas and notes: <https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg>
 * Previous meetings can be viewed on the [TAG YouTube Channel](https://www.youtube.com/watch?v=eZYSQnsWRco&list=PLjNzvzqUSpxKH8X7wNfYZtkH_ARSeeQH0)

--- a/website/content/ko/wgs/platforms/_index.md
+++ b/website/content/ko/wgs/platforms/_index.md
@@ -25,7 +25,7 @@ To register for updates and to "Join" the group, please also consider joining th
 
 * Meeting schedule: 2nd and 4th Tuesday of each month at [1600 Europe/London time](https://www.timeanddate.com/worldclock/converter.html?iso=20240514T150000&p1=136)
 * Please RSVP for meetings on the [TAG App Delivery Community Groups Page](https://community.cncf.io/tag-app-delivery/). This will also provide a calendar entry.
-* Meeting Location, Zoom: https://zoom-lfx.platform.linuxfoundation.org/meeting/94326372364?password=0681764d-b152-4295-8bd2-6b9fcf77bff1
-    * Passcode: 77777
+* Meeting Location, Virtual: <https://zoom-lfx.platform.linuxfoundation.org/meeting/95319413756?password=a945340e-f322-437f-9653-cbf3f05ada69>
+  * Passcode: 77777
 * Agendas and notes: <https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg>
 * Previous meetings can be viewed on the [TAG YouTube Channel](https://www.youtube.com/watch?v=eZYSQnsWRco&list=PLjNzvzqUSpxKH8X7wNfYZtkH_ARSeeQH0)

--- a/website/content/zh/wgs/platforms/_index.md
+++ b/website/content/zh/wgs/platforms/_index.md
@@ -25,7 +25,7 @@ To register for updates and to "Join" the group, please also consider joining th
 
 * Meeting schedule: 2nd and 4th Tuesday of each month at [1600 Europe/London time](https://www.timeanddate.com/worldclock/converter.html?iso=20240514T150000&p1=136)
 * Please RSVP for meetings on the [TAG App Delivery Community Groups Page](https://community.cncf.io/tag-app-delivery/). This will also provide a calendar entry.
-* Meeting Location, Zoom: https://zoom-lfx.platform.linuxfoundation.org/meeting/94326372364?password=0681764d-b152-4295-8bd2-6b9fcf77bff1
-    * Passcode: 77777
+* Meeting Location, Virtual: <https://zoom-lfx.platform.linuxfoundation.org/meeting/95319413756?password=a945340e-f322-437f-9653-cbf3f05ada69>
+  * Passcode: 77777
 * Agendas and notes: <https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg>
 * Previous meetings can be viewed on the [TAG YouTube Channel](https://www.youtube.com/watch?v=eZYSQnsWRco&list=PLjNzvzqUSpxKH8X7wNfYZtkH_ARSeeQH0)


### PR DESCRIPTION
This updates the meeting link to the LFX link