### PR TITLE
feat: updated management

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,13 +10,16 @@
 #
 # Unless a later match takes precedence, these owners will be requested for
 # review when someone opens a pull request.
-*   @thschue @lianmakesthings @kgamanji @linsun @AloisReitbauer @roberthstrand
+* @lianmakesthings @kgamanji @linsun @roberthstrand @schristoff @GenPage
 
 # Platforms WG
-/platforms-*/ @thschue @lianmakesthings @kgamanji @abangser @roberthstrand @krumware @linsun @AloisReitbauer @techmaharaj
+/platforms-*/ @lianmakesthings @kgamanji @abangser @roberthstrand @krumware @linsun @techmaharaj
 
 # Artifacts WG
-/artifacts-*/ @thschue @lianmakesthings @kgamanji @sabre1041 @rchincha @linsun @AloisReitbauer @roberthstrand
+/artifacts-*/ @lianmakesthings @kgamanji @sabre1041 @rchincha @linsun @roberthstrand
 
 # App Development WG
-/app-development-*/ @thschue @lianmakesthings @kgamanji @linsun @AloisReitbauer @roberthstrand @salaboy @danieloh30 @ThomasVitale
+/app-development-*/ @lianmakesthings @kgamanji @linsun @roberthstrand @salaboy @danieloh30 @ThomasVitale
+
+# Infrastructure Lifecycle WG
+/infrastructure-lifecycle-*/ @lianmakesthings @kgamanji @linsun @roberthstrand @rynowak @elft3r @bschaatsbergen

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 ## Leads
 
 - Lian Li (@lianmakesthings) (Co-Chair, Term: 2024/04/16 - 2026/04/15)
-- Thomas Schuetz (@thschue) (Co-Chair, Term: 2023/08/30 - 2025/08/29)
 - Roberth Strand (@roberthstrand) (Co-Chair, Term: 2024/08/05 - 2026/08/04)
+- Sarah Christoff (@schristoff) (TL)
+- Dylan Page (@genpage) (TL)
 
 ## TOC Liaisons
 - Katie Gamanji (@kgamanji)
@@ -45,6 +46,7 @@ as well as the [CNCF Community Calendar](https://community.cncf.io/tag-app-deliv
 - Alex Jones (@AlexsJones)
 - Josh Gavant (@joshgav)
 - Karena Angell (@angellk)
+- Thomas Schuetz (@thschue)
 
 ## Working Groups
 


### PR DESCRIPTION
Updated codeowners to reflect the latest management structure. Need to give tech leads and certain WG chairs write rights, I will do a PR to the repo `cncf/people` to solve that.