### PR TITLE
updates meeting info and other links on wg-app-dev page

### DIFF
--- a/app-development-wg/README.md
+++ b/app-development-wg/README.md
@@ -1,6 +1,6 @@
-# App Development WG
+# App Development Working Group
 
-The [charter](./charter) describes the mission and tactics of the App Development working group (WG).
+The [charter](./charter) describes the mission and tactics of the App Development Working Group (WG).
 To participate join us on Slack at
 [#wg-app-development](https://cloud-native.slack.com/archives/C06SKDAQDEX)
 or the meetings described below.
@@ -13,10 +13,13 @@ or the meetings described below.
 
 ## Meetings
 
-* Meeting schedule: 1st and 3rd Wednesday of each month at [1600 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20221213T160000&p1=1440)
-   
-* Agendas and notes: <[https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg](https://docs.google.com/document/d/17IOnJLGIGproKP93m_8Z5-WsZdq5s_UPRA2qQbGG9ks/edit?pli=1#heading=h.wtws91k8c1bo)>
+* Meeting schedule: every two weeks on Wednesday at [1600 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20221213T160000&p1=1440)
+* Meetings are listed on the main [CNCF calendar](https://www.cncf.io/calendar/).
+  * Filter by "App Dev" to see only App Development WG meetings.
+* [Agendas and notes](https://docs.google.com/document/d/17IOnJLGIGproKP93m_8Z5-WsZdq5s_UPRA2qQbGG9ks/edit?pli=1#heading=h.wtws91k8c1bo)
+* [Zoom meeting link](https://zoom-lfx.platform.linuxfoundation.org/meeting/92112638688?password=da0fabda-2d32-4fe2-a1a8-b77fd267b9e8)
+
 
 ## Resources
 
-* Github issues: https://github.com/cncf/tag-app-delivery/issues?q=is%3Aissue+is%3Aopen+label%3Awg-app-development
+* [GitHub issues](https://github.com/cncf/tag-app-delivery/labels/wg-appdev)

--- a/website/content/en/wgs/app-development/_index.md
+++ b/website/content/en/wgs/app-development/_index.md
@@ -3,7 +3,7 @@ title: App Development Working Group
 list_pages: false
 ---
 
-The [charter](./charter) describes the mission and tactics of the App Development working group (WG).
+The [charter](./charter) describes the mission and tactics of the App Development Working Group (WG).
 To participate join us on Slack at
 [#wg-app-development](https://cloud-native.slack.com/archives/C06SKDAQDEX)
 or the meetings described below.
@@ -16,10 +16,13 @@ or the meetings described below.
 
 ## Meetings
 
-* Meeting schedule: 1st and 3rd Wednesday of each month at [1600 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20221213T160000&p1=1440)
-   
-* Agendas and notes: <[https://docs.google.com/document/d/1_smeS9-j-SuHJi0VXjx4g9xiD2-tgqhnlwf5oSMDQgg](https://docs.google.com/document/d/17IOnJLGIGproKP93m_8Z5-WsZdq5s_UPRA2qQbGG9ks/edit?pli=1#heading=h.wtws91k8c1bo)>
+* Meeting schedule: every two weeks on Wednesday at [1600 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20221213T160000&p1=1440)
+* Meetings are listed on the main [CNCF calendar](https://www.cncf.io/calendar/).
+    * Filter by "App Dev" to see only App Development WG meetings.
+* [Agendas and notes](https://docs.google.com/document/d/17IOnJLGIGproKP93m_8Z5-WsZdq5s_UPRA2qQbGG9ks/edit?pli=1#heading=h.wtws91k8c1bo)
+* [Zoom meeting link](https://zoom-lfx.platform.linuxfoundation.org/meeting/92112638688?password=da0fabda-2d32-4fe2-a1a8-b77fd267b9e8)
+
 
 ## Resources
 
-* Github issues: https://github.com/cncf/tag-app-delivery/issues?q=is%3Aissue+is%3Aopen+label%3Awg-app-development
+* [GitHub issues](https://github.com/cncf/tag-app-delivery/labels/wg-appdev)


### PR DESCRIPTION
- updates meeting times
- links to CNCF community calendar
- adds info about how to find WG meetings in mass of calendar events
- hides other links in hyperlinked text
- corrects GH label for finding issues