### PR TITLE
introduce paap research survey in blog post

### DIFF
--- a/website/content/en/blog/announce-paap-survey.md
+++ b/website/content/en/blog/announce-paap-survey.md
@@ -1,0 +1,26 @@
+---
+title: Platform as a Product Research - Now with a Survey!
+slug:  call-participation-paap-survey 
+date:   2024-11-25 12:00:00 +0000
+author: Dominik Kress
+categories:
+- Article
+tags:
+- WG Platforms
+- Platform As A Product
+---
+
+### Expanding Our Platform as a Product Research: Share Your Insights Through Our New Survey!
+
+The CNCF Platforms Working Group is continuing its research to learn how companies build their internal platforms. After sharing our [Platform Engineering Maturity Model](https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/), we are now focusing on **Platform As A Product**. This means treating platform users like customers, making sure the platform meets their needs. Even though many talks and articles discuss this topic, we don't know exactly how many companies use this approach.
+
+At first, we started talking to platform builders from different industries through interviews. If you haven't joined yet, you can still sign up by following our [Invitation To Participate in Platform As A Product Research](https://tag-app-delivery.cncf.io/blog/call-participation-paap-research/). 
+ blog post.
+
+The qualitative insights gained from these interviews are invaluable. However, we found that interviews take a lot of time to plan and conduct. To be more inclusive for people with less time at their hands and collect more data quickly, we created a **survey** based on our interview questions. The survey helps us gather **quantitative data** to go along with the detailed stories from interviews. This combination will give us a better understanding of how teams decide what to build for their users.
+
+And like with the interviews we want to hear from **everyone involved in building platforms**, not just product managers. Whether your team uses product management or another method, your answers are important to our research.
+
+So, if you want to help us with this study, please fill out our [survey here](https://forms.gle/PDjnQSvruXwRrZvk7)! Thank you!
+
+We also invite you to [join the CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) and find us in the [#wg-platforms](https://cloud-native.slack.com/archives/C020RHD43BP) channel. Working group meetings are every two weeks and participation is open to all, you can find the [schedule here](https://tag-app-delivery.cncf.io/wgs/platforms/#meetings)!

--- a/website/content/en/blog/announce-paap-survey.md
+++ b/website/content/en/blog/announce-paap-survey.md
@@ -10,14 +10,14 @@ tags:
 - Platform As A Product
 ---
 
-### Expanding Our Platform as a Product Research: Share Your Insights Through Our New Survey!
+### Expanding Our Platform as a Product Research: [Share Your Insights Through Our New Survey!](https://forms.gle/PDjnQSvruXwRrZvk7)
 
-The CNCF Platforms Working Group is continuing its research to learn how companies build their internal platforms. After sharing our [Platform Engineering Maturity Model](https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/), we are now focusing on **Platform As A Product**. This means treating platform users like customers, making sure the platform meets their needs. Even though many talks and articles discuss this topic, we don't know exactly how many companies use this approach.
+The CNCF Platforms Working Group is continuing its research to learn how companies build their internal platforms. After sharing our [**Platform Engineering Maturity Model**](https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/), we are now focusing on [**Platform As A Product**](https://tag-app-delivery.cncf.io/blog/product-thinking-for-platforms/). This means treating platform users like customers, making sure the platform meets their needs. Even though many talks and articles discuss this topic, we don't know exactly how many companies use this approach.
 
 At first, we started talking to platform builders from different industries through interviews. If you haven't joined yet, you can still sign up by following our [Invitation To Participate in Platform As A Product Research](https://tag-app-delivery.cncf.io/blog/call-participation-paap-research/). 
  blog post.
 
-The qualitative insights gained from these interviews are invaluable. However, we found that interviews take a lot of time to plan and conduct. To be more inclusive for people with less time at their hands and collect more data quickly, we created a **survey** based on our interview questions. The survey helps us gather **quantitative data** to go along with the detailed stories from interviews. This combination will give us a better understanding of how teams decide what to build for their users.
+The qualitative insights gained from these interviews are invaluable. However, we found that interviews take a lot of time to plan and conduct. To be more inclusive for people with less time at their hands and collect more data quickly, we created a [**survey**](https://forms.gle/PDjnQSvruXwRrZvk7) based on our interview questions. The survey helps us gather **quantitative data** to go along with the detailed stories from interviews. This combination will give us a better understanding of how teams decide what to build for their users.
 
 And like with the interviews we want to hear from **everyone involved in building platforms**, not just product managers. Whether your team uses product management or another method, your answers are important to our research.
 


### PR DESCRIPTION
As discussed in our last WG Platforms sync from 19.11.2024 here I want to introduce the PaaP Research Survey in a blog post that we can share. :) 